### PR TITLE
Replace `intervalString` with `formatted()` for `Duration`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
-        "version" : "1.0.6"
+        "revision" : "d8003787efafa82f9805594bc51100be29ac6903"
       }
     },
     {
@@ -52,6 +51,23 @@
       "state" : {
         "revision" : "b51f1d6845b353a2121de1c6a670738ec33561a6",
         "version" : "3.1.0"
+      }
+    },
+    {
+      "identity" : "swift-foundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-foundation.git",
+      "state" : {
+        "revision" : "74fefa176b26a49c9a461dda4bfca9b0a1e7cdcd"
+      }
+    },
+    {
+      "identity" : "swift-foundation-icu",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-foundation-icu",
+      "state" : {
+        "revision" : "11227a889fa93632ab81a43ea153f444fd515398",
+        "version" : "0.0.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,7 +39,7 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
+      "location" : "https://github.com/apple/swift-collections",
       "state" : {
         "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
         "version" : "1.0.6"

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
-        "version" : "1.1.0"
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "4fb7ead803e38949eb1d6fabb849206a72c580f3",
-        "version" : "2.23.0"
+        "revision" : "320bd978cceb8e88c125dcbb774943a92f6286e9",
+        "version" : "2.25.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
-        "version" : "1.19.0"
+        "revision" : "ebf8b9c365a6ce043bf6e6326a04b15589bd285e",
+        "version" : "1.20.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 
 let package = Package(
   name: "swift-sdk-generator",
-  platforms: [.macOS(.v13)],
+  platforms: [.macOS("13.3")],
   products: [
     // Products define the executables and libraries a package produces, and make them visible to other packages.
     .executable(
@@ -28,6 +28,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.3.0"),
     .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.2"),
+    .package(url: "https://github.com/apple/swift-foundation.git", revision: "62500a5"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.3.0"),
     .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.2"),
-    .package(url: "https://github.com/apple/swift-foundation.git", revision: "62500a5"),
+    .package(
+        url: "https://github.com/apple/swift-foundation.git",
+        revision: "74fefa176b26a49c9a461dda4bfca9b0a1e7cdcd"
+    ),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -39,6 +42,7 @@ let package = Package(
         "SwiftSDKGenerator",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+        .product(name: "FoundationInternationalization", package: "swift-foundation")
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -15,6 +15,7 @@ import Logging
 import ServiceLifecycle
 import SwiftSDKGenerator
 import struct SystemPackage.FilePath
+import FoundationInternationalization
 
 @main
 struct GeneratorCLI: AsyncParsableCommand {
@@ -56,7 +57,7 @@ struct GeneratorCLI: AsyncParsableCommand {
       try await serviceGroup.run()
     }
 
-    print("\nTime taken for this generator run: \(elapsed.intervalString).")
+    print("\nTime taken for this generator run: \(elapsed.formatted()).")
   }
 }
 
@@ -67,11 +68,39 @@ extension Triple: ExpressibleByArgument {
   }
 }
 
+  @Option(help: "Version of LLD linker to supply in the bundle.")
+  var lldVersion = "16.0.5"
 extension GeneratorCLI {
   struct GeneratorOptions: ParsableArguments {
     @Option(help: "An arbitrary version number for informational purposes.")
     var bundleVersion = "0.0.1"
 
+  @Option(
+    help: """
+    Linux distribution to use if the target platform is Linux. Available options: `ubuntu`, `rhel`. Default is `ubuntu`.
+    """,
+    transform: LinuxDistribution.Name.init(nameString:)
+  )
+  var linuxDistributionName = LinuxDistribution.Name.ubuntu
+
+  @Option(
+    help: """
+    Version of the Linux distribution used as a target platform. Available options for Ubuntu: `20.04`, \
+    `22.04` (default when `--linux-distribution-name` is `ubuntu`). Available options for RHEL: `ubi9` (default when \
+    `--linux-distribution-name` is `rhel`).
+    """
+  )
+  var linuxDistributionVersion: String?
+
+  @Option(
+    help: """
+    CPU architecture of the host triple of the bundle. Defaults to a triple of the machine this generator is \
+    running on if unspecified. Available options: \(
+      Triple.CPU.allCases.map { "`\($0.rawValue)`" }.joined(separator: ", ")
+    ).
+    """
+  )
+  var hostArch: Triple.CPU? = nil
     @Option(
       help: """
       Name of the SDK bundle. Defaults to a string composed of Swift version, Linux distribution, Linux release \
@@ -80,6 +109,20 @@ extension GeneratorCLI {
     )
     var sdkName: String? = nil
 
+  @Option(
+    help: """
+    CPU architecture of the target triple of the bundle. Same as the host triple CPU architecture if unspecified. \
+    Available options: \(Triple.CPU.allCases.map { "`\($0.rawValue)`" }.joined(separator: ", ")).
+    """
+  )
+  var targetArch: Triple.CPU? = nil
+
+  mutating func run() async throws {
+    let linuxDistributionVersion = switch self.linuxDistributionName {
+    case .rhel:
+      "ubi9"
+    case .ubuntu:
+      "22.04"
     @Flag(
       help: "Experimental: avoid cleaning up toolchain and SDK directories and regenerate the SDK bundle incrementally."
     )
@@ -145,8 +188,16 @@ extension GeneratorCLI {
       }
       return current
     }
+    let linuxDistribution = try LinuxDistribution(name: linuxDistributionName, version: linuxDistributionVersion)
   }
 
+    let elapsed = try await ContinuousClock().measure {
+      try await LocalSwiftSDKGenerator(
+        hostCPUArchitecture: self.hostArch,
+        targetCPUArchitecture: self.targetArch,
+        swiftVersion: self.swiftVersion,
+        swiftBranch: self.swiftBranch,
+        lldVersion: self.lldVersion,
   struct MakeLinuxSDK: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
       commandName: "make-linux-sdk",
@@ -214,6 +265,8 @@ extension GeneratorCLI {
       let recipe = try LinuxRecipe(
         targetTriple: targetTriple,
         linuxDistribution: linuxDistribution,
+        shouldUseDocker: self.withDocker,
+        isVerbose: self.verbose
         swiftVersion: generatorOptions.swiftVersion,
         swiftBranch: generatorOptions.swiftBranch,
         lldVersion: lldVersion,
@@ -222,9 +275,11 @@ extension GeneratorCLI {
         hostSwiftPackagePath: generatorOptions.hostSwiftPackagePath,
         targetSwiftPackagePath: generatorOptions.targetSwiftPackagePath
       )
+      .generateBundle(shouldGenerateFromScratch: !self.incremental)
       try await GeneratorCLI.run(recipe: recipe, hostTriple: hostTriple, targetTriple: targetTriple, options: generatorOptions)
     }
 
+    print("\nTime taken for this generator run: \(elapsed.formatted()).")
     func isInvokedAsDefaultSubcommand() -> Bool {
       let arguments = CommandLine.arguments
       guard arguments.count >= 2 else {


### PR DESCRIPTION
New implementation that landed in Foundation recently means we can delete our own custom implementation.