### PR TITLE
fix error: noCacheKeyConformance

### DIFF
--- a/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
+++ b/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
@@ -172,3 +172,17 @@ extension URL: LeafCacheKey {
     self.description.hash(with: &hashFunction)
   }
 }
+
+extension Array: CacheKey where Element == FilePath.Component {
+    func hash(with hashFunction: inout some HashFunction) {
+        String(reflecting: Self.self).hash(with: &hashFunction)
+        map(\.string).joined(separator: "\n").hash(with: &hashFunction)
+    }
+}
+
+extension Range: CacheKey where Bound == Int {
+    func hash(with hashFunction: inout some HashFunction) {
+        String(reflecting: Self.self).hash(with: &hashFunction)
+        description.hash(with: &hashFunction)
+    }
+}


### PR DESCRIPTION
fix:noCacheKeyConformance(Swift.Array<SystemPackage.FilePath.Component>) fix:noCacheKeyConformance(Swift.Range<Swift.Int>)