### PR TITLE
Untar using `-xf` instead of `-xzf`

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -243,7 +243,7 @@ public actor SwiftSDKGenerator {
       stripComponentsOption = ""
     }
     try await Shell.run(
-      #"tar -C "\#(directoryPath)" \#(stripComponentsOption) -xzf \#(file)"#,
+      #"tar -C "\#(directoryPath)" \#(stripComponentsOption) -xf \#(file)"#,
       shouldLogCommands: self.isVerbose
     )
   }


### PR DESCRIPTION
### Fixes #112 

Unpacking XZ-compressed archives (like `host_llvm_17.0.5_x86_64-unknown-linux.tar.xz`) with GNU tar requires either using the `-J` flag or none at all (rather than the `-z` flag, which seems to be reserved for gzip). On macOS, `-xzf` behaves like `-xf`, which is likely why this issue didn't come up there.

With `-xf` both macOS and GNU tar automatically recognize the right format.