### PR TITLE
Ran `swiftformat .` on main. No other changes.

### DIFF
--- a/Sources/AsyncProcess/FileContentStream.swift
+++ b/Sources/AsyncProcess/FileContentStream.swift
@@ -183,11 +183,11 @@ private final class ReadIntoAsyncChannelHandler: ChannelDuplexHandler {
   private var shouldRead: Bool {
     switch self.state {
     case .idle:
-      return true
+      true
     case .error:
-      return false
+      false
     case .sending:
-      return false
+      false
     }
   }
 

--- a/Sources/AsyncProcess/ProcessExecutor+Convenience.swift
+++ b/Sources/AsyncProcess/ProcessExecutor+Convenience.swift
@@ -37,18 +37,18 @@ public struct OutputLoggingSettings: Sendable {
   func logMessage(line: String) -> Logger.Message {
     switch self.to {
     case .logMessage:
-      return "\(line)"
+      "\(line)"
     case .metadata(logMessage: let message, key: _):
-      return message
+      message
     }
   }
 
   func metadata(stream: ProcessOutputStream, line: String) -> Logger.Metadata {
     switch self.to {
     case .logMessage:
-      return ["stream": "\(stream.description)"]
+      ["stream": "\(stream.description)"]
     case .metadata(logMessage: _, let key):
-      return [key: "\(line)"]
+      [key: "\(line)"]
     }
   }
 }

--- a/Sources/AsyncProcess/ProcessExecutor.swift
+++ b/Sources/AsyncProcess/ProcessExecutor.swift
@@ -33,9 +33,9 @@ public struct ProcessOutputStream: Sendable & Hashable & CustomStringConvertible
   public var description: String {
     switch self.backing {
     case .standardOutput:
-      return "stdout"
+      "stdout"
     case .standardError:
-      return "stderr"
+      "stderr"
     }
   }
 }

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -138,7 +138,7 @@ extension GeneratorCLI {
       if let host {
         return host
       }
-      let current = try SwiftSDKGenerator.getCurrentTriple(isVerbose: verbose)
+      let current = try SwiftSDKGenerator.getCurrentTriple(isVerbose: self.verbose)
       if let arch = hostArch {
         let target = Triple(arch: arch, vendor: current.vendor!, os: current.os!)
         print("deprecated: Please use `--host \(target.triple)` instead of `--host-arch \(arch)`")
@@ -198,15 +198,16 @@ extension GeneratorCLI {
     }
 
     func run() async throws {
-      if isInvokedAsDefaultSubcommand() {
-        print("deprecated: Please explicity specify the subcommand to run. For example: $ swift-sdk-generator make-linux-sdk")
+      if self.isInvokedAsDefaultSubcommand() {
+        print(
+          "deprecated: Please explicity specify the subcommand to run. For example: $ swift-sdk-generator make-linux-sdk"
+        )
       }
-      let linuxDistributionDefaultVersion: String
-      switch self.linuxDistributionName {
+      let linuxDistributionDefaultVersion = switch self.linuxDistributionName {
       case .rhel:
-        linuxDistributionDefaultVersion = "ubi9"
+        "ubi9"
       case .ubuntu:
-        linuxDistributionDefaultVersion = "22.04"
+        "22.04"
       }
       let linuxDistributionVersion = self.linuxDistributionVersion ?? linuxDistributionDefaultVersion
       let linuxDistribution = try LinuxDistribution(name: linuxDistributionName, version: linuxDistributionVersion)
@@ -218,14 +219,14 @@ extension GeneratorCLI {
         hostTriple: hostTriple,
         linuxDistribution: linuxDistribution,
         swiftVersion: generatorOptions.swiftVersion,
-        swiftBranch: generatorOptions.swiftBranch,
-        lldVersion: lldVersion,
-        withDocker: withDocker,
-        fromContainerImage: fromContainerImage,
-        hostSwiftPackagePath: generatorOptions.hostSwiftPackagePath,
-        targetSwiftPackagePath: generatorOptions.targetSwiftPackagePath
+        swiftBranch: self.generatorOptions.swiftBranch,
+        lldVersion: self.lldVersion,
+        withDocker: self.withDocker,
+        fromContainerImage: self.fromContainerImage,
+        hostSwiftPackagePath: self.generatorOptions.hostSwiftPackagePath,
+        targetSwiftPackagePath: self.generatorOptions.targetSwiftPackagePath
       )
-      try await GeneratorCLI.run(recipe: recipe, targetTriple: targetTriple, options: generatorOptions)
+      try await GeneratorCLI.run(recipe: recipe, targetTriple: targetTriple, options: self.generatorOptions)
     }
 
     func isInvokedAsDefaultSubcommand() -> Bool {
@@ -270,17 +271,17 @@ extension GeneratorCLI {
       guard let targetSwiftPackagePath = generatorOptions.targetSwiftPackagePath else {
         throw StringError("Missing expected argument '--target-swift-package-path'")
       }
-      let recipe = WebAssemblyRecipe(
-        hostSwiftPackage: try generatorOptions.hostSwiftPackagePath.map {
+      let recipe = try WebAssemblyRecipe(
+        hostSwiftPackage: generatorOptions.hostSwiftPackagePath.map {
           let hostTriple = try self.generatorOptions.deriveHostTriple()
           return WebAssemblyRecipe.HostToolchainPackage(path: FilePath($0), triple: hostTriple)
         },
         targetSwiftPackagePath: FilePath(targetSwiftPackagePath),
-        wasiSysroot: FilePath(wasiSysroot),
-        swiftVersion: generatorOptions.swiftVersion
+        wasiSysroot: FilePath(self.wasiSysroot),
+        swiftVersion: self.generatorOptions.swiftVersion
       )
       let targetTriple = self.deriveTargetTriple()
-      try await GeneratorCLI.run(recipe: recipe, targetTriple: targetTriple, options: generatorOptions)
+      try await GeneratorCLI.run(recipe: recipe, targetTriple: targetTriple, options: self.generatorOptions)
     }
   }
 }

--- a/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
+++ b/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
@@ -16,8 +16,7 @@ import struct SystemPackage.FilePath
 
 /// Indicates that values of a conforming type can be hashed with an arbitrary hashing function. Unlike `Hashable`,
 /// this protocol doesn't utilize random seed values and produces consistent hash values across process launches.
-public protocol CacheKey: Encodable {
-}
+public protocol CacheKey: Encodable {}
 
 /// Types that cannot be decomposed more to be hashed
 protocol LeafCacheKey: CacheKey {

--- a/Sources/GeneratorEngine/Cache/SQLite.swift
+++ b/Sources/GeneratorEngine/Cache/SQLite.swift
@@ -135,11 +135,11 @@ public final class SQLite {
     var pathString: String {
       switch self {
       case let .path(path):
-        return path.string
+        path.string
       case .memory:
-        return ":memory:"
+        ":memory:"
       case .temporary:
-        return ""
+        ""
       }
     }
   }

--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -11,108 +11,107 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Crypto
+import Helpers
 import struct Logging.Logger
 @_exported import struct SystemPackage.FilePath
-import Helpers
 
 public func withEngine(
-    _ fileSystem: any FileSystem,
-    _ logger: Logger,
-    cacheLocation: SQLite.Location,
-    _ body: @Sendable (Engine) async throws -> Void
+  _ fileSystem: any FileSystem,
+  _ logger: Logger,
+  cacheLocation: SQLite.Location,
+  _ body: @Sendable (Engine) async throws -> ()
 ) async throws {
-    let engine = Engine(
-        fileSystem,
-        logger,
-        cacheLocation: cacheLocation
-    )
+  let engine = Engine(
+    fileSystem,
+    logger,
+    cacheLocation: cacheLocation
+  )
 
-    try await withAsyncThrowing {
-        try await body(engine)
-    } defer: {
-        try await engine.shutDown()
-    }
+  try await withAsyncThrowing {
+    try await body(engine)
+  } defer: {
+    try await engine.shutDown()
+  }
 }
 
 /// Cacheable computations engine. Currently the engine makes an assumption that computations produce same results for
 /// the same query values and write results to a single file path.
 public actor Engine {
-    private(set) var cacheHits = 0
-    private(set) var cacheMisses = 0
+  private(set) var cacheHits = 0
+  private(set) var cacheMisses = 0
 
-    public let fileSystem: any FileSystem
-    public let logger: Logger
-    private let resultsCache: SQLiteBackedCache
-    private var isShutDown = false
+  public let fileSystem: any FileSystem
+  public let logger: Logger
+  private let resultsCache: SQLiteBackedCache
+  private var isShutDown = false
 
-    /// Creates a new instance of the ``QueryEngine`` actor. Requires an explicit call
-    /// to ``QueryEngine//shutdown`` before the instance is deinitialized. The recommended approach to resource
-    /// management is to place `engine.shutDown()` when the engine is no longer used, but is not deinitialized yet.
-    /// - Parameter fileSystem: Implementation of a file system this engine should use.
-    /// - Parameter cacheLocation: Location of cache storage used by the engine.
-    /// - Parameter logger: Logger to use during queries execution.
-    init(
-        _ fileSystem: any FileSystem,
-        _ logger: Logger,
-        cacheLocation: SQLite.Location
-    ) {
-        self.fileSystem = fileSystem
-        self.logger = logger
-        self.resultsCache = SQLiteBackedCache(tableName: "cache_table", location: cacheLocation, logger)
-    }
+  /// Creates a new instance of the ``QueryEngine`` actor. Requires an explicit call
+  /// to ``QueryEngine//shutdown`` before the instance is deinitialized. The recommended approach to resource
+  /// management is to place `engine.shutDown()` when the engine is no longer used, but is not deinitialized yet.
+  /// - Parameter fileSystem: Implementation of a file system this engine should use.
+  /// - Parameter cacheLocation: Location of cache storage used by the engine.
+  /// - Parameter logger: Logger to use during queries execution.
+  init(
+    _ fileSystem: any FileSystem,
+    _ logger: Logger,
+    cacheLocation: SQLite.Location
+  ) {
+    self.fileSystem = fileSystem
+    self.logger = logger
+    self.resultsCache = SQLiteBackedCache(tableName: "cache_table", location: cacheLocation, logger)
+  }
 
-    public func shutDown() async throws {
-        precondition(!self.isShutDown, "`QueryEngine/shutDown` should be called only once")
-        try self.resultsCache.close()
+  public func shutDown() async throws {
+    precondition(!self.isShutDown, "`QueryEngine/shutDown` should be called only once")
+    try self.resultsCache.close()
 
-        self.isShutDown = true
-    }
+    self.isShutDown = true
+  }
 
-    deinit {
-        let isShutDown = self.isShutDown
-        precondition(
-            isShutDown,
-            "`QueryEngine/shutDown` should be called explicitly on instances of `Engine` before deinitialization"
-        )
-    }
+  deinit {
+    let isShutDown = self.isShutDown
+    precondition(
+      isShutDown,
+      "`QueryEngine/shutDown` should be called explicitly on instances of `Engine` before deinitialization"
+    )
+  }
 
-    /// Executes a given query if no cached result of it is available. Otherwise fetches the result from engine's cache.
-    /// - Parameter query: A query value to execute.
-    /// - Returns: A file path to query's result recorded in a file.
-    public subscript(_ query: some Query) -> FileCacheRecord {
-        get async throws {
-            let hashEncoder = HashEncoder<SHA512>()
-            try hashEncoder.encode(query.cacheKey)
-            let key = hashEncoder.finalize()
+  /// Executes a given query if no cached result of it is available. Otherwise fetches the result from engine's cache.
+  /// - Parameter query: A query value to execute.
+  /// - Returns: A file path to query's result recorded in a file.
+  public subscript(_ query: some Query) -> FileCacheRecord {
+    get async throws {
+      let hashEncoder = HashEncoder<SHA512>()
+      try hashEncoder.encode(query.cacheKey)
+      let key = hashEncoder.finalize()
 
-            if let fileRecord = try resultsCache.get(key, as: FileCacheRecord.self) {
-
-                let fileHash = try await self.fileSystem.withOpenReadableFile(fileRecord.path) {
-                    var hashFunction = SHA512()
-                    try await $0.hash(with: &hashFunction)
-                    return hashFunction.finalize().description
-                }
-
-                if fileHash == fileRecord.hash {
-                    self.cacheHits += 1
-                    return fileRecord
-                }
-            }
-
-            self.cacheMisses += 1
-            let resultPath = try await query.run(engine: self)
-
-            let resultHash = try await self.fileSystem.withOpenReadableFile(resultPath) {
-                var hashFunction = SHA512()
-                try await $0.hash(with: &hashFunction)
-                return hashFunction.finalize().description
-            }
-            let result = FileCacheRecord(path: resultPath, hash: resultHash)
-
-            // FIXME: update `SQLiteBackedCache` to store `resultHash` directly instead of relying on string conversions
-            try self.resultsCache.set(key, to: result)
-
-            return result
+      if let fileRecord = try resultsCache.get(key, as: FileCacheRecord.self) {
+        let fileHash = try await self.fileSystem.withOpenReadableFile(fileRecord.path) {
+          var hashFunction = SHA512()
+          try await $0.hash(with: &hashFunction)
+          return hashFunction.finalize().description
         }
+
+        if fileHash == fileRecord.hash {
+          self.cacheHits += 1
+          return fileRecord
+        }
+      }
+
+      self.cacheMisses += 1
+      let resultPath = try await query.run(engine: self)
+
+      let resultHash = try await self.fileSystem.withOpenReadableFile(resultPath) {
+        var hashFunction = SHA512()
+        try await $0.hash(with: &hashFunction)
+        return hashFunction.finalize().description
+      }
+      let result = FileCacheRecord(path: resultPath, hash: resultHash)
+
+      // FIXME: update `SQLiteBackedCache` to store `resultHash` directly instead of relying on string conversions
+      try self.resultsCache.set(key, to: result)
+
+      return result
     }
+  }
 }

--- a/Sources/GeneratorEngine/FileSystem/FileSystem.swift
+++ b/Sources/GeneratorEngine/FileSystem/FileSystem.swift
@@ -28,9 +28,9 @@ enum FileSystemError: Error {
 extension Error {
   func attach(path: FilePath) -> any Error {
     if let error = self as? Errno {
-      return FileSystemError.systemError(path, error)
+      FileSystemError.systemError(path, error)
     } else {
-      return self
+      self
     }
   }
 }

--- a/Sources/GeneratorEngine/FileSystem/OpenReadableFile.swift
+++ b/Sources/GeneratorEngine/FileSystem/OpenReadableFile.swift
@@ -25,9 +25,9 @@ public struct OpenReadableFile {
   func read() async throws -> ReadableFileStream {
     switch self.fileHandle {
     case let .local(fileDescriptor):
-      return ReadableFileStream.local(.init(fileDescriptor: fileDescriptor, readChunkSize: self.readChunkSize))
+      ReadableFileStream.local(.init(fileDescriptor: fileDescriptor, readChunkSize: self.readChunkSize))
     case let .virtual(array):
-      return ReadableFileStream.virtual(.init(bytes: array))
+      ReadableFileStream.virtual(.init(bytes: array))
     }
   }
 

--- a/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
+++ b/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
@@ -25,9 +25,9 @@ public enum ReadableFileStream: AsyncSequence {
     public func next() async throws -> [UInt8]? {
       switch self {
       case let .local(local):
-        return try await local.next()
+        try await local.next()
       case let .virtual(virtual):
-        return try await virtual.next()
+        try await virtual.next()
       }
     }
   }
@@ -35,9 +35,9 @@ public enum ReadableFileStream: AsyncSequence {
   public func makeAsyncIterator() -> Iterator {
     switch self {
     case let .local(local):
-      return .local(local.makeAsyncIterator())
+      .local(local.makeAsyncIterator())
     case let .virtual(virtual):
-      return .virtual(virtual.makeAsyncIterator())
+      .virtual(virtual.makeAsyncIterator())
     }
   }
 }

--- a/Sources/GeneratorEngine/Query.swift
+++ b/Sources/GeneratorEngine/Query.swift
@@ -19,256 +19,258 @@ public protocol Query: Sendable {
 }
 
 public protocol CachingQuery: Query, CacheKey where Self.Key == Self {}
-extension CachingQuery {
-  public var cacheKey: Key { self }
+public extension CachingQuery {
+  var cacheKey: Key { self }
 }
 
 final class HashEncoder<Hash: HashFunction>: Encoder {
-    enum Error: Swift.Error {
-        case noCacheKeyConformance(Encodable.Type)
-    }
+  enum Error: Swift.Error {
+    case noCacheKeyConformance(Encodable.Type)
+  }
 
-    var codingPath: [any CodingKey]
-    
-    var userInfo: [CodingUserInfoKey : Any]
-    
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        return .init(KeyedContainer(encoder: self))
-    }
-    
-    func unkeyedContainer() -> any UnkeyedEncodingContainer {
-        self
-    }
-    
-    func singleValueContainer() -> any SingleValueEncodingContainer {
-        self
-    }
-    
-    init() {
-        self.hashFunction = Hash()
-        self.codingPath = []
-        self.userInfo = [:]
-    }
-    
-    fileprivate var hashFunction = Hash()
+  var codingPath: [any CodingKey]
 
-    func finalize() -> Hash.Digest {
-        hashFunction.finalize()
-    }
+  var userInfo: [CodingUserInfoKey: Any]
+
+  func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+    .init(KeyedContainer(encoder: self))
+  }
+
+  func unkeyedContainer() -> any UnkeyedEncodingContainer {
+    self
+  }
+
+  func singleValueContainer() -> any SingleValueEncodingContainer {
+    self
+  }
+
+  init() {
+    self.hashFunction = Hash()
+    self.codingPath = []
+    self.userInfo = [:]
+  }
+
+  fileprivate var hashFunction = Hash()
+
+  func finalize() -> Hash.Digest {
+    self.hashFunction.finalize()
+  }
 }
 
 extension HashEncoder: SingleValueEncodingContainer {
-    func encodeNil() throws {
-        // FIXME: this doesn't encode the name of the underlying optional type,
-        // but `Encoder` protocol is limited and can't provide this for us.
-        var str = "nil"
-        str.withUTF8 {
-            self.hashFunction.update(data: $0)
-        }
+  func encodeNil() throws {
+    // FIXME: this doesn't encode the name of the underlying optional type,
+    // but `Encoder` protocol is limited and can't provide this for us.
+    var str = "nil"
+    str.withUTF8 {
+      self.hashFunction.update(data: $0)
     }
+  }
 
-    func encode(_ value: Bool) throws {
-        value.hash(with: &self.hashFunction)
+  func encode(_ value: Bool) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: String) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: Double) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: Float) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: Int) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: Int8) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: Int16) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: Int32) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: Int64) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: UInt) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: UInt8) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: UInt16) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: UInt32) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode(_ value: UInt64) throws {
+    value.hash(with: &self.hashFunction)
+  }
+
+  func encode<T>(_ value: T) throws where T: Encodable {
+    guard value is CacheKey else {
+      throw Error.noCacheKeyConformance(T.self)
     }
-    
-    func encode(_ value: String) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: Double) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: Float) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: Int) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: Int8) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: Int16) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: Int32) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: Int64) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: UInt) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: UInt8) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: UInt16) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: UInt32) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode(_ value: UInt64) throws {
-        value.hash(with: &self.hashFunction)
-    }
-    
-    func encode<T>(_ value: T) throws where T : Encodable {
-        guard value is CacheKey else {
-            throw Error.noCacheKeyConformance(T.self)
-        }
-        try String(describing: T.self).encode(to: self)
-        try value.encode(to: self)
-    }
+    try String(describing: T.self).encode(to: self)
+    try value.encode(to: self)
+  }
 }
 
 extension HashEncoder: UnkeyedEncodingContainer {
-    var count: Int {
-        0
-    }
-    
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        KeyedEncodingContainer(KeyedContainer(encoder: self))
-    }
-    
-    func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
-        self
-    }
-    
-    func superEncoder() -> any Encoder {
-        fatalError()
-    }
+  var count: Int {
+    0
+  }
+
+  func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey>
+    where NestedKey: CodingKey
+  {
+    KeyedEncodingContainer(KeyedContainer(encoder: self))
+  }
+
+  func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+    self
+  }
+
+  func superEncoder() -> any Encoder {
+    fatalError()
+  }
 }
 
 extension HashEncoder {
-    struct KeyedContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
-        var encoder: HashEncoder
-        var codingPath: [any CodingKey] { self.encoder.codingPath }
+  struct KeyedContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+    var encoder: HashEncoder
+    var codingPath: [any CodingKey] { self.encoder.codingPath }
 
-        mutating func encodeNil(forKey key: K) throws {
-            // FIXME: this doesn't encode the name of the underlying optional type,
-            // but `Encoder` protocol is limited and can't provide this for us.
-            var str = "nil"
-            str.withUTF8 {
-                self.encoder.hashFunction.update(data: $0)
-            }
-        }
-        
-        mutating func encode(_ value: Bool, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: String, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: Double, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: Float, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: Int, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: Int8, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: Int16, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: Int32, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: Int64, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: UInt, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: UInt8, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: UInt16, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: UInt32, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode(_ value: UInt64, forKey key: K) throws {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            value.hash(with: &self.encoder.hashFunction)
-        }
-        
-        mutating func encode<T>(_ value: T, forKey key: K) throws where T : Encodable {
-            if let leaf = value as? LeafCacheKey {
-                leaf.hash(with: &self.encoder.hashFunction)
-                return
-            }
-            guard value is CacheKey else {
-                throw Error.noCacheKeyConformance(T.self)
-            }
-
-            try String(reflecting: T.self).encode(to: self.encoder)
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            try value.encode(to: self.encoder)
-        }
-
-        mutating func nestedContainer<NestedKey>(
-            keyedBy keyType: NestedKey.Type,
-            forKey key: K
-        ) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            return self.encoder.nestedContainer(keyedBy: keyType)
-        }
-
-        mutating func nestedUnkeyedContainer(forKey key: K) -> any UnkeyedEncodingContainer {
-            key.stringValue.hash(with: &self.encoder.hashFunction)
-            return self.encoder
-        }
-
-        mutating func superEncoder() -> any Encoder {
-            fatalError()
-        }
-
-        mutating func superEncoder(forKey key: K) -> any Encoder {
-            fatalError()
-        }
-
-        typealias Key = K
+    mutating func encodeNil(forKey key: K) throws {
+      // FIXME: this doesn't encode the name of the underlying optional type,
+      // but `Encoder` protocol is limited and can't provide this for us.
+      var str = "nil"
+      str.withUTF8 {
+        self.encoder.hashFunction.update(data: $0)
+      }
     }
+
+    mutating func encode(_ value: Bool, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: String, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: Double, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: Float, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: Int, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: Int8, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: Int16, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: Int32, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: Int64, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: UInt, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: UInt8, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: UInt16, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: UInt32, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode(_ value: UInt64, forKey key: K) throws {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      value.hash(with: &self.encoder.hashFunction)
+    }
+
+    mutating func encode<T>(_ value: T, forKey key: K) throws where T: Encodable {
+      if let leaf = value as? LeafCacheKey {
+        leaf.hash(with: &self.encoder.hashFunction)
+        return
+      }
+      guard value is CacheKey else {
+        throw Error.noCacheKeyConformance(T.self)
+      }
+
+      try String(reflecting: T.self).encode(to: self.encoder)
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      try value.encode(to: self.encoder)
+    }
+
+    mutating func nestedContainer<NestedKey>(
+      keyedBy keyType: NestedKey.Type,
+      forKey key: K
+    ) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      return self.encoder.nestedContainer(keyedBy: keyType)
+    }
+
+    mutating func nestedUnkeyedContainer(forKey key: K) -> any UnkeyedEncodingContainer {
+      key.stringValue.hash(with: &self.encoder.hashFunction)
+      return self.encoder
+    }
+
+    mutating func superEncoder() -> any Encoder {
+      fatalError()
+    }
+
+    mutating func superEncoder(forKey key: K) -> any Encoder {
+      fatalError()
+    }
+
+    typealias Key = K
+  }
 }

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -17,10 +17,10 @@ import struct SystemPackage.FilePath
 private extension Triple {
   var llvmBinaryURLSuffix: String {
     switch (self.os, self.arch) {
-    case (.linux, .aarch64): return "aarch64-linux-gnu"
-    case (.linux, .x86_64): return "x86_64-linux-gnu-ubuntu-22.04"
-    case (.macosx, .aarch64): return "arm64-apple-darwin22.0"
-    case (.macosx, .x86_64): return "x86_64-apple-darwin22.0"
+    case (.linux, .aarch64): "aarch64-linux-gnu"
+    case (.linux, .x86_64): "x86_64-linux-gnu-ubuntu-22.04"
+    case (.macosx, .aarch64): "arm64-apple-darwin22.0"
+    case (.macosx, .x86_64): "x86_64-apple-darwin22.0"
     default: fatalError("\(self) is not supported as LLVM host platform yet")
     }
   }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -13,7 +13,11 @@
 import SystemPackage
 
 extension SwiftSDKGenerator {
-  func copyTargetSwiftFromDocker(targetDistribution: LinuxDistribution, baseDockerImage: String, sdkDirPath: FilePath) async throws {
+  func copyTargetSwiftFromDocker(
+    targetDistribution: LinuxDistribution,
+    baseDockerImage: String,
+    sdkDirPath: FilePath
+  ) async throws {
     logGenerationStep("Launching a Docker container to copy Swift SDK for the target triple from it...")
     try await withDockerContainer(fromImage: baseDockerImage) { containerID in
       try await inTemporaryDirectory { generator, _ in
@@ -45,7 +49,8 @@ extension SwiftSDKGenerator {
         }
 
         if case let containerLib64 = FilePath("/usr/lib64"),
-           try await generator.doesPathExist(containerLib64, inContainer: containerID) {
+           try await generator.doesPathExist(containerLib64, inContainer: containerID)
+        {
           let sdkUsrLib64Path = sdkUsrPath.appending("lib64")
           // we already checked that the path exists above, so we don't pass `failIfNotExists: false` here.
           try await generator.copyFromDockerContainer(
@@ -59,7 +64,7 @@ extension SwiftSDKGenerator {
         let sdkUsrLibPath = sdkUsrPath.appending("lib")
         try await generator.createDirectoryIfNeeded(at: sdkUsrLibPath)
         var subpaths: [(subpath: String, failIfNotExists: Bool)] = [
-          ("clang", true), ("gcc", true), ("swift", true), ("swift_static", true)
+          ("clang", true), ("gcc", true), ("swift", true), ("swift_static", true),
         ]
 
         // Ubuntu's multiarch directory scheme puts some libraries in

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -125,7 +125,12 @@ extension SwiftSDKGenerator {
     try createDirectoryIfNeeded(at: pathsConfiguration.toolchainBinDirPath)
   }
 
-  func downloadFiles(from urls: [URL], to directory: FilePath, _ client: some HTTPClientProtocol, _ engine: Engine) async throws -> [(URL, UInt64)] {
+  func downloadFiles(
+    from urls: [URL],
+    to directory: FilePath,
+    _ client: some HTTPClientProtocol,
+    _ engine: Engine
+  ) async throws -> [(URL, UInt64)] {
     try await withThrowingTaskGroup(of: (URL, UInt64).self) {
       for url in urls {
         $0.addTask {
@@ -176,11 +181,10 @@ extension HTTPClientProtocol {
     targetTriple: Triple,
     isVerbose: Bool
   ) async throws -> [String: URL] {
-    let mirrorURL: String
-    if targetTriple.arch == .x86_64 {
-      mirrorURL = ubuntuAMD64Mirror
+    let mirrorURL: String = if targetTriple.arch == .x86_64 {
+      ubuntuAMD64Mirror
     } else {
-      mirrorURL = ubuntuARM64Mirror
+      ubuntuARM64Mirror
     }
 
     let packagesListURL = """

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -16,24 +16,24 @@ import AsyncHTTPClient
 #endif
 import Foundation
 import GeneratorEngine
+import Helpers
 import RegexBuilder
 import SystemPackage
-import Helpers
 
 public extension Triple.Arch {
   /// Returns the value of `cpu` converted to a convention used in Debian package names
   var debianConventionName: String {
     switch self {
-    case .aarch64: return "arm64"
-    case .x86_64: return "amd64"
-    case .wasm32: return "wasm32"
+    case .aarch64: "arm64"
+    case .x86_64: "amd64"
+    case .wasm32: "wasm32"
     default: fatalError("\(self) is not supported yet")
     }
   }
 }
 
-extension SwiftSDKGenerator {
-  public func run(recipe: SwiftSDKRecipe) async throws {
+public extension SwiftSDKGenerator {
+  func run(recipe: SwiftSDKRecipe) async throws {
     try await withEngine(LocalFileSystem(), self.logger, cacheLocation: self.engineCachePath) { engine in
       let httpClientType: HTTPClientProtocol.Type
       #if canImport(AsyncHTTPClient)
@@ -53,7 +53,11 @@ extension SwiftSDKGenerator {
 
         let toolsetJSONPath = try await generateToolsetJSON(recipe: recipe)
 
-        try await generateDestinationJSON(toolsetPath: toolsetJSONPath, sdkDirPath: swiftSDKProduct.sdkDirPath, recipe: recipe)
+        try await generateDestinationJSON(
+          toolsetPath: toolsetJSONPath,
+          sdkDirPath: swiftSDKProduct.sdkDirPath,
+          recipe: recipe
+        )
 
         try await generateArtifactBundleManifest(hostTriples: swiftSDKProduct.hostTriples)
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -67,7 +67,11 @@ extension SwiftSDKGenerator {
     }
   }
 
-  func unpackTargetSwiftPackage(targetSwiftPackagePath: FilePath, relativePathToRoot: [FilePath.Component], sdkDirPath: FilePath) async throws {
+  func unpackTargetSwiftPackage(
+    targetSwiftPackagePath: FilePath,
+    relativePathToRoot: [FilePath.Component],
+    sdkDirPath: FilePath
+  ) async throws {
     logGenerationStep("Unpacking Swift distribution for the target triple...")
 
     try await inTemporaryDirectory { fs, tmpDir in
@@ -93,11 +97,10 @@ extension SwiftSDKGenerator {
       stripComponents: 1
     )
 
-    let unpackedLLDPath: FilePath
-    if llvmArtifact.isPrebuilt {
-      unpackedLLDPath = untarDestination.appending("bin/lld")
+    let unpackedLLDPath: FilePath = if llvmArtifact.isPrebuilt {
+      untarDestination.appending("bin/lld")
     } else {
-      unpackedLLDPath = try await engine[CMakeBuildQuery(
+      try await engine[CMakeBuildQuery(
         sourcesDirectory: untarDestination,
         outputBinarySubpath: ["bin", "lld"],
         options: "-DLLVM_ENABLE_PROJECTS=lld -DLLVM_TARGETS_TO_BUILD=''"

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -12,9 +12,9 @@
 
 import Foundation
 import GeneratorEngine
+import Helpers
 import Logging
 import SystemPackage
-import Helpers
 
 /// Top-level actor that sequences all of the required SDK generation steps.
 public actor SwiftSDKGenerator {
@@ -115,7 +115,7 @@ public actor SwiftSDKGenerator {
     failIfNotExists: Bool = true
   ) async throws {
     if !failIfNotExists {
-      guard try await doesPathExist(containerPath, inContainer: id)
+      guard try await self.doesPathExist(containerPath, inContainer: id)
       else { return }
     }
     try await Shell.run(
@@ -133,13 +133,15 @@ public actor SwiftSDKGenerator {
     )
   }
 
-  func withDockerContainer(fromImage imageName: String,
-                           _ body: @Sendable (String) async throws -> ()) async throws {
+  func withDockerContainer(
+    fromImage imageName: String,
+    _ body: @Sendable (String) async throws -> ()
+  ) async throws {
     let containerID = try await launchDockerContainer(imageName: imageName)
     try await withAsyncThrowing {
       try await body(containerID)
     } defer: {
-      try await stopDockerContainer(id: containerID)
+      try await self.stopDockerContainer(id: containerID)
     }
   }
 
@@ -236,11 +238,10 @@ public actor SwiftSDKGenerator {
     into directoryPath: FilePath,
     stripComponents: Int? = nil
   ) async throws {
-    let stripComponentsOption: String
-    if let stripComponents {
-      stripComponentsOption = "--strip-components=\(stripComponents)"
+    let stripComponentsOption = if let stripComponents {
+      "--strip-components=\(stripComponents)"
     } else {
-      stripComponentsOption = ""
+      ""
     }
     try await Shell.run(
       #"tar -C "\#(directoryPath)" \#(stripComponentsOption) -xf \#(file)"#,

--- a/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
@@ -41,14 +41,14 @@ public enum LinuxDistribution: Hashable, Sendable {
 
     var version: String {
       switch self {
-      case .focal: return "20.04"
-      case .jammy: return "22.04"
+      case .focal: "20.04"
+      case .jammy: "22.04"
       }
     }
 
     public var requiredPackages: [String] {
       switch self {
-      case .focal: return [
+      case .focal: [
           "libc6",
           "libc6-dev",
           "libgcc-s1",
@@ -62,7 +62,7 @@ public enum LinuxDistribution: Hashable, Sendable {
           "zlib1g-dev",
           "libc6",
         ]
-      case .jammy: return [
+      case .jammy: [
           "libc6",
           "libc6-dev",
           "libgcc-s1",
@@ -97,22 +97,22 @@ public enum LinuxDistribution: Hashable, Sendable {
 
   var name: Name {
     switch self {
-    case .rhel: return .rhel
-    case .ubuntu: return .ubuntu
+    case .rhel: .rhel
+    case .ubuntu: .ubuntu
     }
   }
 
   var release: String {
     switch self {
-    case let .rhel(rhel): return rhel.rawValue
-    case let .ubuntu(ubuntu): return ubuntu.rawValue
+    case let .rhel(rhel): rhel.rawValue
+    case let .ubuntu(ubuntu): ubuntu.rawValue
     }
   }
 
   var swiftDockerImageSuffix: String {
     switch self {
-    case let .rhel(rhel): return "rhel-\(rhel.rawValue)"
-    case let .ubuntu(ubuntu): return ubuntu.rawValue
+    case let .rhel(rhel): "rhel-\(rhel.rawValue)"
+    case let .ubuntu(ubuntu): ubuntu.rawValue
     }
   }
 }
@@ -128,12 +128,11 @@ public extension LinuxDistribution.Name {
 
 extension LinuxDistribution: CustomStringConvertible {
   public var description: String {
-    let versionComponent: String
-    switch self {
+    let versionComponent: String = switch self {
     case .rhel:
-      versionComponent = self.release.uppercased()
+      self.release.uppercased()
     case .ubuntu:
-      versionComponent = self.release.capitalized
+      self.release.capitalized
     }
 
     return "\(self.name) \(versionComponent)"
@@ -143,8 +142,8 @@ extension LinuxDistribution: CustomStringConvertible {
 extension LinuxDistribution.Name: CustomStringConvertible {
   public var description: String {
     switch self {
-    case .rhel: return "RHEL"
-    case .ubuntu: return "Ubuntu"
+    case .rhel: "RHEL"
+    case .ubuntu: "Ubuntu"
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -16,13 +16,12 @@ public typealias Triple = Helpers.Triple
 
 extension Triple: @unchecked Sendable {}
 
-extension Triple {
-
-  public init(arch: Arch, vendor: Vendor?, os: OS, environment: Environment) {
+public extension Triple {
+  init(arch: Arch, vendor: Vendor?, os: OS, environment: Environment) {
     self.init("\(arch)-\(vendor?.rawValue ?? "unknown")-\(os)-\(environment)", normalizing: true)
   }
 
-  public init(arch: Arch, vendor: Vendor?, os: OS) {
+  init(arch: Arch, vendor: Vendor?, os: OS) {
     self.init("\(arch)-\(vendor?.rawValue ?? "unknown")-\(os)", normalizing: true)
   }
 }
@@ -31,9 +30,9 @@ extension Triple.Arch {
   /// Returns the value of `cpu` converted to a convention used by Swift on Linux, i.e. `arm64` becomes `aarch64`.
   var linuxConventionName: String {
     switch self {
-    case .aarch64: return "aarch64"
-    case .x86_64: return "x86_64"
-    case .wasm32: return "wasm32"
+    case .aarch64: "aarch64"
+    case .x86_64: "x86_64"
+    case .wasm32: "wasm32"
     default: fatalError("\(self) is not supported yet")
     }
   }
@@ -41,9 +40,9 @@ extension Triple.Arch {
   /// Returns the value of `cpu` converted to a convention used by `LLVM_TARGETS_TO_BUILD` CMake setting.
   var llvmTargetConventionName: String {
     switch self {
-    case .x86_64: return "X86"
-    case .aarch64: return "AArch64"
-    case .wasm32: return "WebAssembly"
+    case .x86_64: "X86"
+    case .aarch64: "AArch64"
+    case .wasm32: "WebAssembly"
     default: fatalError("\(self) is not supported yet")
     }
   }

--- a/Sources/SwiftSDKGenerator/PlatformModels/VersionsConfiguration.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/VersionsConfiguration.swift
@@ -36,9 +36,9 @@ public struct VersionsConfiguration: Sendable {
   var swiftPlatform: String {
     switch self.linuxDistribution {
     case let .ubuntu(ubuntu):
-      return "ubuntu\(ubuntu.version)\(self.linuxArchSuffix)"
+      "ubuntu\(ubuntu.version)\(self.linuxArchSuffix)"
     case let .rhel(rhel):
-      return "\(rhel.rawValue)\(self.linuxArchSuffix)"
+      "\(rhel.rawValue)\(self.linuxArchSuffix)"
     }
   }
 
@@ -51,12 +51,11 @@ public struct VersionsConfiguration: Sendable {
     platform: String? = nil,
     fileExtension: String = "tar.gz"
   ) -> URL {
-    let computedSubdirectory: String
-    switch self.linuxDistribution {
+    let computedSubdirectory: String = switch self.linuxDistribution {
     case let .ubuntu(ubuntu):
-      computedSubdirectory = "ubuntu\(ubuntu.version.replacingOccurrences(of: ".", with: ""))\(self.linuxArchSuffix)"
+      "ubuntu\(ubuntu.version.replacingOccurrences(of: ".", with: ""))\(self.linuxArchSuffix)"
     case let .rhel(rhel):
-      computedSubdirectory = rhel.rawValue
+      rhel.rawValue
     }
 
     return URL(
@@ -77,7 +76,7 @@ public struct VersionsConfiguration: Sendable {
   /// Name of a Docker image containing the Swift toolchain and SDK for this Linux distribution.
   var swiftBaseDockerImage: String {
     if self.swiftVersion.hasSuffix("-RELEASE") {
-      return "swift:\(self.swiftBareSemVer)-\(self.linuxDistribution.swiftDockerImageSuffix)"
+      "swift:\(self.swiftBareSemVer)-\(self.linuxDistribution.swiftDockerImageSuffix)"
     } else {
       fatalError()
     }

--- a/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
@@ -31,8 +31,11 @@ struct CMakeBuildQuery: CachingQuery {
     )
 
     let buildDirectory = self.sourcesDirectory.appending("build")
-    try await Shell.run(#"ninja -C "\#(buildDirectory)" "\#(FilePath(".").appending(outputBinarySubpath))""#, logStdout: true)
+    try await Shell.run(
+      #"ninja -C "\#(buildDirectory)" "\#(FilePath(".").appending(self.outputBinarySubpath))""#,
+      logStdout: true
+    )
 
-    return buildDirectory.appending(outputBinarySubpath)
+    return buildDirectory.appending(self.outputBinarySubpath)
   }
 }

--- a/Sources/SwiftSDKGenerator/Queries/DownloadArtifactQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/DownloadArtifactQuery.swift
@@ -14,20 +14,20 @@ import GeneratorEngine
 import struct SystemPackage.FilePath
 
 struct DownloadArtifactQuery: Query {
-  var cacheKey: some CacheKey { artifact }
+  var cacheKey: some CacheKey { self.artifact }
   let artifact: DownloadableArtifacts.Item
   let httpClient: any HTTPClientProtocol
 
   func run(engine: Engine) async throws -> FilePath {
     print("Downloading remote artifact not available in local cache: \(self.artifact.remoteURL)")
-    let stream = httpClient.streamDownloadProgress(
+    let stream = self.httpClient.streamDownloadProgress(
       from: self.artifact.remoteURL, to: self.artifact.localPath
     )
-      .removeDuplicates(by: didProgressChangeSignificantly)
-      ._throttle(for: .seconds(1))
+    .removeDuplicates(by: didProgressChangeSignificantly)
+    ._throttle(for: .seconds(1))
 
     for try await progress in stream {
-      report(progress: progress, for: artifact)
+      report(progress: progress, for: self.artifact)
     }
     return self.artifact.localPath
   }

--- a/Sources/SwiftSDKGenerator/Queries/DownloadFileQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/DownloadFileQuery.swift
@@ -19,16 +19,18 @@ struct DownloadFileQuery: Query {
     let remoteURL: URL
     let localDirectory: FilePath
   }
+
   var cacheKey: Key {
-    Key(remoteURL: remoteURL, localDirectory: localDirectory)
+    Key(remoteURL: self.remoteURL, localDirectory: self.localDirectory)
   }
+
   let remoteURL: URL
   let localDirectory: FilePath
   let httpClient: any HTTPClientProtocol
 
   func run(engine: Engine) async throws -> FilePath {
     let downloadedFilePath = self.localDirectory.appending(self.remoteURL.lastPathComponent)
-    _ = try await httpClient.downloadFile(from: self.remoteURL, to: downloadedFilePath)
+    _ = try await self.httpClient.downloadFile(from: self.remoteURL, to: downloadedFilePath)
     return downloadedFilePath
   }
 }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -71,11 +71,10 @@ public struct LinuxRecipe: SwiftSDKRecipe {
         targetSwiftSource = .remoteTarball
       }
     }
-    let hostSwiftSource: HostSwiftSource
-    if let hostSwiftPackagePath {
-      hostSwiftSource = .localPackage(FilePath(hostSwiftPackagePath))
+    let hostSwiftSource: HostSwiftSource = if let hostSwiftPackagePath {
+      .localPackage(FilePath(hostSwiftPackagePath))
     } else {
-      hostSwiftSource = .remoteTarball
+      .remoteTarball
     }
 
     self.init(
@@ -105,7 +104,11 @@ public struct LinuxRecipe: SwiftSDKRecipe {
   }
 
   public func applyPlatformOptions(toolset: inout Toolset, targetTriple: Triple) {
-    toolset.swiftCompiler = Toolset.ToolProperties(extraCLIOptions: ["-use-ld=lld", "-Xlinker", "-R/usr/lib/swift/linux/"])
+    toolset.swiftCompiler = Toolset.ToolProperties(extraCLIOptions: [
+      "-use-ld=lld",
+      "-Xlinker",
+      "-R/usr/lib/swift/linux/",
+    ])
     toolset.cxxCompiler = Toolset.ToolProperties(extraCLIOptions: ["-lstdc++"])
     toolset.linker = Toolset.ToolProperties(path: "ld.lld")
     toolset.librarian = Toolset.ToolProperties(path: "llvm-ar")
@@ -113,15 +116,18 @@ public struct LinuxRecipe: SwiftSDKRecipe {
 
   public var defaultArtifactID: String {
     """
-    \(versionsConfiguration.swiftVersion)_\(linuxDistribution.name.rawValue)_\(linuxDistribution.release)_\(
-    mainTargetTriple.arch!.linuxConventionName
+    \(self.versionsConfiguration.swiftVersion)_\(self.linuxDistribution.name.rawValue)_\(
+      self.linuxDistribution
+        .release
+    )_\(
+      self.mainTargetTriple.arch!.linuxConventionName
     )
     """
   }
 
   func sdkDirPath(paths: PathsConfiguration) -> FilePath {
     paths.swiftSDKRootPath
-      .appending("\(linuxDistribution.name.rawValue)-\(linuxDistribution.release).sdk")
+      .appending("\(self.linuxDistribution.name.rawValue)-\(self.linuxDistribution.release).sdk")
   }
 
   public func makeSwiftSDK(
@@ -138,7 +144,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     var downloadableArtifacts = try DownloadableArtifacts(
       hostTriple: mainHostTriple,
       targetTriple: generator.targetTriple,
-      versionsConfiguration,
+      self.versionsConfiguration,
       generator.pathsConfiguration
     )
 
@@ -148,12 +154,12 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       downloadableArtifacts: &downloadableArtifacts,
       itemsToDownload: { artifacts in
         var items = [artifacts.hostLLVM]
-        switch targetSwiftSource {
+        switch self.targetSwiftSource {
         case .remoteTarball:
           items.append(artifacts.targetSwift)
         case .docker, .localPackage: break
         }
-        switch hostSwiftSource {
+        switch self.hostSwiftSource {
         case .remoteTarball:
           items.append(artifacts.hostSwift)
         case .localPackage: break
@@ -172,13 +178,13 @@ public struct LinuxRecipe: SwiftSDKRecipe {
         client,
         engine,
         requiredPackages: version.requiredPackages,
-        versionsConfiguration: versionsConfiguration,
+        versionsConfiguration: self.versionsConfiguration,
         sdkDirPath: sdkDirPath
       )
     }
 
     switch self.hostSwiftSource {
-    case .localPackage(let filePath):
+    case let .localPackage(filePath):
       try await generator.rsync(
         from: filePath.appending("usr"), to: generator.pathsConfiguration.toolchainDirPath
       )
@@ -195,14 +201,14 @@ public struct LinuxRecipe: SwiftSDKRecipe {
         baseDockerImage: baseSwiftDockerImage,
         sdkDirPath: sdkDirPath
       )
-    case .localPackage(let filePath):
+    case let .localPackage(filePath):
       try await generator.copyTargetSwift(
         from: filePath.appending("usr/lib"), sdkDirPath: sdkDirPath
       )
     case .remoteTarball:
       try await generator.unpackTargetSwiftPackage(
         targetSwiftPackagePath: downloadableArtifacts.targetSwift.localPath,
-        relativePathToRoot: [FilePath.Component(versionsConfiguration.swiftDistributionName())!],
+        relativePathToRoot: [FilePath.Component(self.versionsConfiguration.swiftDistributionName())!],
         sdkDirPath: sdkDirPath
       )
     }
@@ -215,7 +221,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     try await generator.fixGlibcModuleMap(
       at: generator.pathsConfiguration.toolchainDirPath
         .appending("/usr/lib/swift/linux/\(targetCPU.linuxConventionName)/glibc.modulemap"),
-      hostTriple: mainHostTriple
+      hostTriple: self.mainHostTriple
     )
 
     try await generator.symlinkClangHeaders()
@@ -227,6 +233,6 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       try await generator.createSymlink(at: autolinkExtractPath, pointingTo: "swift")
     }
 
-    return SwiftSDKProduct(sdkDirPath: sdkDirPath, hostTriples: [mainHostTriple])
+    return SwiftSDKProduct(sdkDirPath: sdkDirPath, hostTriples: [self.mainHostTriple])
   }
 }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
@@ -35,12 +35,13 @@ public protocol SwiftSDKRecipe: Sendable {
   var defaultArtifactID: String { get }
 
   /// The main entrypoint of the recipe to make a Swift SDK
-  func makeSwiftSDK(generator: SwiftSDKGenerator, engine: Engine, httpClient: some HTTPClientProtocol) async throws -> SwiftSDKProduct
+  func makeSwiftSDK(generator: SwiftSDKGenerator, engine: Engine, httpClient: some HTTPClientProtocol) async throws
+    -> SwiftSDKProduct
 }
 
-extension SwiftSDKRecipe {
-  public func applyPlatformOptions(toolset: inout Toolset, targetTriple: Triple) {}
-  public func applyPlatformOptions(
+public extension SwiftSDKRecipe {
+  func applyPlatformOptions(toolset: inout Toolset, targetTriple: Triple) {}
+  func applyPlatformOptions(
     metadata: inout SwiftSDKMetadataV4.TripleProperties,
     paths: PathsConfiguration,
     targetTriple: Triple

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -52,7 +52,7 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
       // Enable features required for threading support
       let ccOptions = [
         "-matomics", "-mbulk-memory", "-mthread-model", "posix",
-        "-pthread", "-ftls-model=local-exec"
+        "-pthread", "-ftls-model=local-exec",
       ]
       // Tell LLVM codegen in swiftc to enable those features via clang options
       toolset.swiftCompiler?.extraCLIOptions?.append(contentsOf: ccOptions.flatMap {
@@ -125,7 +125,8 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
 
     // WebAssembly object file requires `swift-autolink-extract`
     if await !generator.doesFileExist(at: autolinkExtractPath),
-       await generator.doesFileExist(at: generator.pathsConfiguration.toolchainBinDirPath.appending("swift")) {
+       await generator.doesFileExist(at: generator.pathsConfiguration.toolchainBinDirPath.appending("swift"))
+    {
       logGenerationStep("Fixing `swift-autolink-extract` symlink...")
       try await generator.createSymlink(at: autolinkExtractPath, pointingTo: "swift")
     }
@@ -150,7 +151,7 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
       // Mark CoreFoundation as optional until we set up build system to build it for WebAssembly
       ("swift_static/CoreFoundation", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static"), true),
     ] {
-      if isOptional, !(await generator.doesFileExist(at: distributionPath.appending(pathWithinPackage))) {
+      if isOptional, await !(generator.doesFileExist(at: distributionPath.appending(pathWithinPackage))) {
         logGenerationStep("Skipping optional path \(pathWithinPackage)")
         continue
       }

--- a/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
@@ -32,32 +32,32 @@ extension GeneratorError: CustomStringConvertible {
   var description: String {
     switch self {
     case let .noProcessOutput(process):
-      return "Failed to read standard output of a launched process: \(process)"
+      "Failed to read standard output of a launched process: \(process)"
     case let .unhandledChildProcessSignal(signal, commandInfo):
-      return "Process launched with \(commandInfo) finished due to signal \(signal)"
+      "Process launched with \(commandInfo) finished due to signal \(signal)"
     case let .nonZeroExitCode(exitCode, commandInfo):
-      return "Process launched with \(commandInfo) failed with exit code \(exitCode)"
+      "Process launched with \(commandInfo) failed with exit code \(exitCode)"
     case let .unknownLinuxDistribution(name, version):
-      return "Linux distribution `\(name)`\(version.map { " with version \($0)" } ?? "")` is not supported by this generator."
+      "Linux distribution `\(name)`\(version.map { " with version \($0)" } ?? "")` is not supported by this generator."
     case let .unknownMacOSVersion(version):
-      return "macOS version `\(version)` is not supported by this generator."
+      "macOS version `\(version)` is not supported by this generator."
     case let .unknownCPUArchitecture(cpu):
-      return "CPU architecture `\(cpu)` is not supported by this generator."
+      "CPU architecture `\(cpu)` is not supported by this generator."
     case let .unknownLLDVersion(version):
-      return "LLD version `\(version)` is not supported by this generator."
+      "LLD version `\(version)` is not supported by this generator."
     case let .distributionSupportsOnlyDockerGenerator(linuxDistribution):
-      return """
+      """
       Target Linux distribution \(linuxDistribution) supports Swift SDK generation only when `--with-docker` flag is \
       passed.
       """
     case let .fileDoesNotExist(filePath):
-      return "Expected to find a file at path `\(filePath)`."
+      "Expected to find a file at path `\(filePath)`."
     case let .fileDownloadFailed(url, status):
-      return "File could not be downloaded from a URL `\(url)`, the server returned status `\(status)`."
+      "File could not be downloaded from a URL `\(url)`, the server returned status `\(status)`."
     case .ubuntuPackagesDecompressionFailure:
-      return "Failed to decompress the list of Ubuntu packages"
+      "Failed to decompress the list of Ubuntu packages"
     case let .ubuntuPackagesParsingFailure(expected, actual):
-      return "Failed to parse Ubuntu packages manifest, expected \(expected), found \(actual) packages."
+      "Failed to parse Ubuntu packages manifest, expected \(expected), found \(actual) packages."
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/SystemUtils/HTTPClient+Download.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/HTTPClient+Download.swift
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import SystemPackage
-import NIOHTTP1
-import NIOCore
 import Helpers
+import NIOCore
+import NIOHTTP1
+import SystemPackage
 
 public struct DownloadProgress: Sendable {
-    public var totalBytes: Int?
-    public var receivedBytes: Int
+  public var totalBytes: Int?
+  public var receivedBytes: Int
 }
 
 public protocol HTTPClientProtocol: Sendable {
@@ -41,7 +41,7 @@ public protocol HTTPClientProtocol: Sendable {
     from url: URL,
     to path: FilePath
   ) -> AsyncThrowingStream<DownloadProgress, any Error>
-  
+
   /// Perform GET request to the given URL.
   func get(url: String) async throws -> (
     status: NIOHTTP1.HTTPResponseStatus,
@@ -53,8 +53,10 @@ public protocol HTTPClientProtocol: Sendable {
 }
 
 extension HTTPClientProtocol {
-  static func with<Result: Sendable>(_ body: @Sendable (any HTTPClientProtocol) async throws -> Result) async throws -> Result {
-    try await with(http1Only: false, body)
+  static func with<Result: Sendable>(_ body: @Sendable (any HTTPClientProtocol) async throws -> Result) async throws
+    -> Result
+  {
+    try await self.with(http1Only: false, body)
   }
 }
 
@@ -62,6 +64,7 @@ extension FilePath: @unchecked Sendable {}
 
 #if canImport(AsyncHTTPClient)
 import AsyncHTTPClient
+
 extension FileDownloadDelegate.Progress: @unchecked Sendable {}
 
 extension HTTPClient: HTTPClientProtocol {
@@ -96,7 +99,7 @@ extension HTTPClient: HTTPClientProtocol {
     from url: URL,
     to path: FilePath
   ) async throws {
-    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
       do {
         let delegate = try FileDownloadDelegate(
           path: path.string,
@@ -170,6 +173,7 @@ struct OfflineHTTPClient: HTTPClientProtocol {
     let client = OfflineHTTPClient()
     return try await body(client)
   }
+
   public func downloadFile(from url: URL, to path: SystemPackage.FilePath) async throws {
     throw FileOperationError.downloadFailed(url, "Cannot fetch file with offline client")
   }

--- a/Sources/SwiftSDKGenerator/SystemUtils/UnixName.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/UnixName.swift
@@ -12,7 +12,7 @@ struct UnixName {
   init(info: utsname) {
     var info = info
 
-    func cloneCString<CString>(_ value: inout CString) -> String {
+    func cloneCString(_ value: inout some Any) -> String {
       withUnsafePointer(to: &value) {
         String(cString: UnsafeRawPointer($0).assumingMemoryBound(to: CChar.self))
       }

--- a/Tests/GeneratorEngineTests/EngineTests.swift
+++ b/Tests/GeneratorEngineTests/EngineTests.swift
@@ -157,7 +157,9 @@ final class EngineTests: XCTestCase {
 
   func testQueryEncoding() throws {
     let item = MyItem(
-      remoteURL: URL(string: "https://download.swift.org/swift-5.9.2-release/ubuntu2204-aarch64/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04-aarch64.tar.gz")!,
+      remoteURL: URL(
+        string: "https://download.swift.org/swift-5.9.2-release/ubuntu2204-aarch64/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04-aarch64.tar.gz"
+      )!,
       localPath: "/Users/katei/ghq/github.com/apple/swift-sdk-generator/Artifacts/target_swift_5.9.2-RELEASE_aarch64-unknown-linux-gnu.tar.gz",
       isPrebuilt: true
     )

--- a/Tests/HelpersTests/ThrowingDeferTests.swift
+++ b/Tests/HelpersTests/ThrowingDeferTests.swift
@@ -29,7 +29,7 @@ final class ThrowingDeferTests: XCTestCase {
     }
 
     func run() throws {
-      didRun = true
+      self.didRun = true
       if let error {
         throw error
       }
@@ -37,6 +37,7 @@ final class ThrowingDeferTests: XCTestCase {
   }
 
   // MARK: - Non-Async
+
   func testThrowingDeferWithoutThrowing() throws {
     var didRunWork = false
     var didRunCleanup = false
@@ -99,6 +100,7 @@ final class ThrowingDeferTests: XCTestCase {
   }
 
   // MARK: - Async
+
   func testAsyncThrowingDeferWithoutThrowing() async throws {
     let work = Worker()
     let cleanup = Worker()

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -32,7 +32,7 @@ final class EndToEndTests: XCTestCase {
       }
 
       atexit(fin)
-    """#
+    """#,
   ]
 
   private let logger = Logger(label: "swift-sdk-generator")
@@ -78,7 +78,7 @@ final class EndToEndTests: XCTestCase {
       let installOutput = try await Shell.readStdout(String(installCommand))
       XCTAssertTrue(installOutput.contains("successfully installed"))
 
-      for testcase in testcases {
+      for testcase in self.testcases {
         let testPackageURL = FileManager.default.temporaryDirectory.appendingPathComponent("swift-sdk-generator-test")
         let testPackageDir = FilePath(testPackageURL.path)
         try? fm.removeItem(atPath: testPackageDir.string)

--- a/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -16,7 +16,7 @@ import XCTest
 
 final class WebAssemblyRecipeTests: XCTestCase {
   func createRecipe() -> WebAssemblyRecipe {
-    return WebAssemblyRecipe(
+    WebAssemblyRecipe(
       hostSwiftPackage: nil,
       targetSwiftPackagePath: "./target-toolchain",
       wasiSysroot: "./wasi-sysroot",
@@ -25,7 +25,7 @@ final class WebAssemblyRecipeTests: XCTestCase {
   }
 
   func testToolOptions() {
-    let recipe = createRecipe()
+    let recipe = self.createRecipe()
     var toolset = Toolset(rootPath: nil)
     recipe.applyPlatformOptions(
       toolset: &toolset, targetTriple: Triple("wasm32-unknown-wasi")
@@ -37,7 +37,7 @@ final class WebAssemblyRecipeTests: XCTestCase {
   }
 
   func testToolOptionsWithThreads() {
-    let recipe = createRecipe()
+    let recipe = self.createRecipe()
     var toolset = Toolset(rootPath: nil)
     recipe.applyPlatformOptions(
       toolset: &toolset, targetTriple: Triple("wasm32-unknown-wasip1-threads")
@@ -51,18 +51,18 @@ final class WebAssemblyRecipeTests: XCTestCase {
         "-Xcc", "-mthread-model",
         "-Xcc", "posix",
         "-Xcc", "-pthread",
-        "-Xcc", "-ftls-model=local-exec"
+        "-Xcc", "-ftls-model=local-exec",
       ]
     )
 
     let ccOptions = [
       "-matomics", "-mbulk-memory", "-mthread-model", "posix",
-      "-pthread", "-ftls-model=local-exec"
+      "-pthread", "-ftls-model=local-exec",
     ]
     XCTAssertEqual(toolset.cCompiler?.extraCLIOptions, ccOptions)
     XCTAssertEqual(toolset.cxxCompiler?.extraCLIOptions, ccOptions)
     XCTAssertEqual(toolset.linker?.extraCLIOptions, [
-      "--import-memory", "--export-memory", "--shared-memory", "--max-memory=1073741824"
+      "--import-memory", "--export-memory", "--shared-memory", "--max-memory=1073741824",
     ])
   }
 }


### PR DESCRIPTION
Motivation:

Have main pass the soundness checks.

Modifications:

`CONTRIBUTING.md` recommends running the `./Utilities/soundness.sh` script before making changes to the project. This script runs the `swiftformat .` command which currently modifies 34 of the files on main with no other changes to the project.

Result:

Bring main up to formatting requirements specified by `CONTRIBUTING.md`.