### PR TITLE
Downgrade .swiftformat to Swift 5.8

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -14,4 +14,4 @@
 # Insert explicit `self` where applicable.
 --self insert
 
---swiftversion 5.9
+--swiftversion 5.8


### PR DESCRIPTION
Compatibility with Swift 5.8 should be maintained for as long as we're building with Swift 5.8 on CI.