### PR TITLE
Fix a compatibility issue with Swift 6.0 and `main` snapshots

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -225,7 +225,9 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       hostTriple: self.mainHostTriple
     )
 
-    try await generator.symlinkClangHeaders()
+    if versionsConfiguration.swiftVersion.hasPrefix("5.9") || versionsConfiguration.swiftVersion.hasPrefix("5.10") {
+      try await generator.symlinkClangHeaders()
+    }
 
     let autolinkExtractPath = generator.pathsConfiguration.toolchainBinDirPath.appending("swift-autolink-extract")
 


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift-sdk-generator/issues/121.

It doesn't seem that projects depending on Foundation can be cross-compiled with 6.0 Swift SDKs (`error: missing required module '_FoundationCShims'), but at least the generation process completes successfully.