### PR TITLE
Reduce Linux builds verbosity in `test.sh`

### DIFF
--- a/Utilities/test.sh
+++ b/Utilities/test.sh
@@ -16,5 +16,5 @@ set -ex
 if [ "$(uname)" = Darwin ]; then
     swift test $@
 else
-    swift build --build-tests --vv $@
+    swift build --build-tests $@
 fi


### PR DESCRIPTION
`-vv` makes logs too large and hard to read. We don't need that logging level right now and can easily bring it back when needed.