### PR TITLE
Bump default version of Swift to 5.10.1

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -98,7 +98,7 @@ extension GeneratorCLI {
     var swiftBranch: String? = nil
 
     @Option(help: "Version of Swift to supply in the bundle.")
-    var swiftVersion = "5.9.2-RELEASE"
+    var swiftVersion = "5.10.1-RELEASE"
 
     @Option(
       help: """


### PR DESCRIPTION
Verified manually that `swift-sdk-generator` itself can be cross-compiled when using https://github.com/swiftlang/swift-sdk-generator/pull/127.