### PR TITLE
WasmSDK: Copy swift-foundation headers and apinotes into the Swift SDK bundle

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -123,6 +123,7 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
       try await self.mergeTargetSwift(from: targetSwiftLibPath, generator: generator)
     } else {
       // Simply copy the target Swift package into the SDK bundle when building host-agnostic SDK.
+      try await generator.createDirectoryIfNeeded(at: pathsConfiguration.toolchainDirPath.appending("usr"))
       try await generator.copy(from: targetSwiftLibPath, to: pathsConfiguration.toolchainDirPath.appending("usr/lib"))
     }
 


### PR DESCRIPTION
Those files are recently added to the toolchain, and they are required to build Swift code that uses Foundation on WebAssembly.

We had been manually specifying the paths to copy from the target package into the SDK, but we now build host-agnostic SDKS. So we can just copy the whole `usr/lib` from the target Swift package into the SDK bundle instead of adding individual new paths. The host-specific build path is still used for 5.10 SDKs, so keep the old code as is for now, but it will be removed in the future.