### PR TITLE
Add `/.index-build` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.index-build
 /Packages
 /*.xcodeproj
 xcuserdata/


### PR DESCRIPTION
This allows SourceKit-LSP background indexing files to be ignored.