### PR TITLE
Address Foundation-related FIXME in `GeneratorCLI.swift`

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -287,7 +287,6 @@ extension GeneratorCLI {
   }
 }
 
-// FIXME: replace this with a call on `.formatted()` on `Duration` when it's available in swift-foundation.
 import Foundation
 
 extension Duration {
@@ -298,10 +297,18 @@ extension Duration {
     let components = Calendar.current.dateComponents([.hour, .minute, .second], from: reference, to: date)
 
     if let hours = components.hour, hours > 0 {
+      #if !canImport(Darwin) && compiler(<6.0)
       return String(format: "%02d:%02d:%02d", hours, components.minute ?? 0, components.second ?? 0)
+      #else
+      return self.formatted()
+      #endif
     } else if let minutes = components.minute, minutes > 0 {
+      #if !canImport(Darwin) && compiler(<6.0)
       let seconds = components.second ?? 0
       return "\(minutes) minute\(minutes != 1 ? "s" : "") \(seconds) second\(seconds != 1 ? "s" : "")"
+      #else
+      return "\(self.formatted(.time(pattern: .minuteSecond))) seconds"
+      #endif
     } else {
       return "\(components.second ?? 0) seconds"
     }


### PR DESCRIPTION
Now that `Duration.formatted()` is available on non-Darwin platforms in Swift 6.0+ we can utilize it in `GeneratorCLI.swift` and address a long-standing `FIXME`.