### PR TITLE
generator/linux: Use `swiftResourcesPath` to find framework headers

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -101,9 +101,6 @@ extension SwiftSDKGenerator {
       ("swift/linux", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift")),
       ("swift_static/linux", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),
       ("swift_static/shims", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),
-      ("swift/dispatch", sdkDirPath.appending("usr/include")),
-      ("swift/os", sdkDirPath.appending("usr/include")),
-      ("swift/CoreFoundation", sdkDirPath.appending("usr/include")),
     ] {
       try await rsync(from: distributionPath.appending(pathWithinPackage), to: pathWithinSwiftSDK)
     }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -115,6 +115,19 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     toolset.librarian = Toolset.ToolProperties(path: "llvm-ar")
   }
 
+  public func applyPlatformOptions(
+    metadata: inout SwiftSDKMetadataV4.TripleProperties,
+    paths: PathsConfiguration,
+    targetTriple: Triple
+  ) {
+    var relativeSDKDir = self.sdkDirPath(paths: paths)
+    guard relativeSDKDir.removePrefix(paths.swiftSDKRootPath) else {
+      fatalError("The SDK directory path must be a subdirectory of the Swift SDK root path.")
+    }
+    metadata.swiftResourcesPath = relativeSDKDir.appending("usr/lib/swift").string
+    metadata.swiftStaticResourcesPath = relativeSDKDir.appending("usr/lib/swift_static").string
+  }
+
   public var defaultArtifactID: String {
     """
     \(self.versionsConfiguration.swiftVersion)_\(self.linuxDistribution.name.rawValue)_\(


### PR DESCRIPTION
Building with a Swift 6.0 SDK fails because the new `_FoundationCShims` framework headers can't be found:

    <unknown>:0: error: missing required module '_FoundationCShims'

The necessary files are present in `$PLATFORM.sdk/usr/lib/swift`, but are not part of the list which is copied to
`$PLATFORM.sdk/usr/include`.  The Static Linux SDK and WASM SDK generator don't copy these files into /usr/include;  instead they set the `swiftResourcesPath` and `swiftStaticResourcesPath` fields in `swift-sdk.json`, which causes the build system to look in those paths for framework headers.

We can do the same for Linux SDKs, however we must stop copying the files to `/usr/include`, otherwise the build will fail because the framework header definitions are duplicated:

    error: redefinition of module 'DispatchIntrospection'
     6 | }
     7 |
     8 | module DispatchIntrospection [system] [extern_c] {
       |        `- error: redefinition of module 'DispatchIntrospection'
     9 |    header "introspection.h"
    10 |    export *

Partial fix for #138 