### PR TITLE
Revert "generator/linux: Use `swiftResourcesPath` to find framework headers"

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -101,6 +101,9 @@ extension SwiftSDKGenerator {
       ("swift/linux", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift")),
       ("swift_static/linux", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),
       ("swift_static/shims", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),
+      ("swift/dispatch", sdkDirPath.appending("usr/include")),
+      ("swift/os", sdkDirPath.appending("usr/include")),
+      ("swift/CoreFoundation", sdkDirPath.appending("usr/include")),
     ] {
       try await rsync(from: distributionPath.appending(pathWithinPackage), to: pathWithinSwiftSDK)
     }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -115,19 +115,6 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     toolset.librarian = Toolset.ToolProperties(path: "llvm-ar")
   }
 
-  public func applyPlatformOptions(
-    metadata: inout SwiftSDKMetadataV4.TripleProperties,
-    paths: PathsConfiguration,
-    targetTriple: Triple
-  ) {
-    var relativeSDKDir = self.sdkDirPath(paths: paths)
-    guard relativeSDKDir.removePrefix(paths.swiftSDKRootPath) else {
-      fatalError("The SDK directory path must be a subdirectory of the Swift SDK root path.")
-    }
-    metadata.swiftResourcesPath = relativeSDKDir.appending("usr/lib/swift").string
-    metadata.swiftStaticResourcesPath = relativeSDKDir.appending("usr/lib/swift_static").string
-  }
-
   public var defaultArtifactID: String {
     """
     \(self.versionsConfiguration.swiftVersion)_\(self.linuxDistribution.name.rawValue)_\(


### PR DESCRIPTION
Reverts swiftlang/swift-sdk-generator#139.  This change fixed Swift 6.0 container-based builds, but broke Debian-based builds.

See #141 