### PR TITLE
tests: Fix EndToEnd test deadlock under `swift test`, but exclude from CI

### DIFF
--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
 
   test:
     <<: *common
+    environment:
+      - JENKINS_URL
     command: /bin/bash -xcl "swift test $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-}"
 
   # util

--- a/Sources/SwiftSDKGenerator/SystemUtils/ByteBuffer+Utils.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/ByteBuffer+Utils.swift
@@ -21,7 +21,7 @@ public extension ByteBuffer {
       standardInput: [self].async,
       collectStandardOutput: true,
       collectStandardError: false,
-      perStreamCollectionLimitBytes: 10 * 1024 * 1024
+      perStreamCollectionLimitBytes: 20 * 1024 * 1024
     )
 
     try result.exitReason.throwIfNonZero()

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -106,8 +106,6 @@ final class EndToEndTests: XCTestCase {
   func testRepeatedSDKBuilds() async throws {
     throw XCTSkip("EndToEnd tests currently deadlock under `swift test`: https://github.com/swiftlang/swift-sdk-generator/issues/143")
 
-    let fm = FileManager.default
-
     var packageDirectory = FilePath(#filePath)
     packageDirectory.removeLastComponent()
     packageDirectory.removeLastComponent()
@@ -123,12 +121,6 @@ final class EndToEndTests: XCTestCase {
     }
 
     for runArguments in possibleArguments {
-      let testPackageURL = FileManager.default.temporaryDirectory.appendingPathComponent("swift-sdk-generator-test")
-      let testPackageDir = FilePath(testPackageURL.path)
-      try? fm.removeItem(atPath: testPackageDir.string)
-      try fm.createDirectory(atPath: testPackageDir.string, withIntermediateDirectories: true)
-      defer { try? fm.removeItem(atPath: testPackageDir.string) }
-
       let firstGeneratorOutput = try await Shell.readStdout(
         "cd \(packageDirectory) && swift run swift-sdk-generator \(runArguments)"
       )


### PR DESCRIPTION
Building an SDK requires running the sdk-generator with `swift run swift-sdk-generator`.  This takes a lock on `.build`, but if the tests are being run by `swift test` the outer Swift Package Manager instance will already hold this lock, causing the test to deadlock. We can avoid this by giving the `swift run swift-sdk-generator` instance its own scratch directory.

This PR consolidates the code which builds SDKs in one function, then runs each SDK build with its own temporary scratch directory.   This avoids the deadlock on the `.build` directory when run under `swift test`.

The tests continue to pass when run under Xcode, which was not affected by the deadlock because it works in a separate scratch directory.

:warning: **The tests cannot currently run in CI because SDK generator cannot use the HTTP proxy to download packages.**   This PR allows the tests to be run locally with `swift test` but skips them when running in the CI.   When the downloading problem is solved, the tests can be enabled in CI as well.

:warning: RHEL-based Swift 6.0 SDKs built from container images currently do not currently work, as reported in #138.   This PR makes it possible to run the test locally under `swift test` while working on this problem, to prevent regressions such as #141.

Fixes #143 