### PR TITLE
tests: Silence warning about not using the make-linux-sdk subcommand

### DIFF
--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -75,7 +75,7 @@ final class EndToEndTests: XCTestCase {
   // the `swift run swift-sdk-generator` instance its own scratch directory.
   func buildSDK(inDirectory packageDirectory: FilePath, scratchPath: String, withArguments runArguments: String) async throws -> String {
     let generatorOutput = try await Shell.readStdout(
-      "cd \(packageDirectory) && swift run --scratch-path \"\(scratchPath)\" swift-sdk-generator \(runArguments)"
+      "cd \(packageDirectory) && swift run --scratch-path \"\(scratchPath)\" swift-sdk-generator make-linux-sdk \(runArguments)"
     )
 
     let installCommand = try XCTUnwrap(generatorOutput.split(separator: "\n").first {


### PR DESCRIPTION
`swift run swift-sdk-generator` still builds a Linux SDK by default, but prints the following warning:

  deprecated: Please explicitly specify the subcommand to run. For example: $ swift-sdk-generator make-linux-sdk