### PR TITLE
generator/linux: Copy ELF interpreter from architecture-specific locations

### DIFF
--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -270,7 +270,6 @@ final class Swift59_UbuntuEndToEndTests: XCTestCase {
   }
 
   func testAarch64FromContainer() async throws {
-    try skipBroken("https://github.com/swiftlang/swift-sdk-generator/issues/147")
     try skipSlow()
     try await buildTestcases(config: config.withArchitecture("aarch64").withDocker())
   }
@@ -300,7 +299,6 @@ final class Swift510_UbuntuEndToEndTests: XCTestCase {
   }
 
   func testAarch64FromContainer() async throws {
-    try skipBroken("https://github.com/swiftlang/swift-sdk-generator/issues/147")
     try skipSlow()
     try await buildTestcases(config: config.withArchitecture("aarch64").withDocker())
   }
@@ -353,7 +351,6 @@ final class Swift59_RHELEndToEndTests: XCTestCase {
   )
 
   func testAarch64FromContainer() async throws {
-    try skipBroken("https://github.com/swiftlang/swift-sdk-generator/issues/147")
     try skipSlow()
     try await buildTestcases(config: config.withArchitecture("aarch64").withDocker())
   }
@@ -373,7 +370,6 @@ final class Swift510_RHELEndToEndTests: XCTestCase {
   )
 
   func testAarch64FromContainer() async throws {
-    try skipBroken("https://github.com/swiftlang/swift-sdk-generator/issues/147")
     try skipSlow()
     try await buildTestcases(config: config.withArchitecture("aarch64").withDocker())
   }
@@ -393,7 +389,7 @@ final class Swift60_RHELEndToEndTests: XCTestCase {
   )
 
   func testAarch64FromContainer() async throws {
-    try skipBroken("https://github.com/swiftlang/swift-sdk-generator/issues/147")
+    try skipBroken("https://github.com/swiftlang/swift-sdk-generator/issues/152")
     try skipSlow()
     try await buildTestcases(config: config.withArchitecture("aarch64").withDocker())
   }


### PR DESCRIPTION
Issue https://github.com/swiftlang/swift-sdk-generator/issues/147 occurs because the ELF interpreter is found at different
paths, and with different names, on different architectures.    We
happen to pick up the x86_64 interpreter because it is stored in /lib64,
which we aready copy, but we miss the aarch64 interpreter.

An ELF binary contains an interpreter path which can point anywhere, but
there are defacto standard default locations.

* According to https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf)
  the x86_64 / amd64 ABI specifies that the interpreter should be
  at /lib/ld64.so.1, but Linux overrides this and uses
  /lib64/ld-linux-x86-64.so.2.

* I couldn't find a similar document for ARM64 / aarch64 -
  https://github.com/ARM-software/abi-aa/tree/main/aaelf64 is silent
  on the interpreter path - but most sources I could find place it
  at /lib/ld-linux-aarch64.so.1 - for example
  https://github.com/zulu-openjdk/zulu-openjdk/issues/11

There is a pattern to the paths and filenames but it seems risky to
try to construct them;  instead this PR adds a new field to `Triple`
which returns the default path for each architecture.   For now we
only support x86_64 and aarch64 - if new architectures are added in
future we will need to add new entries for them.

This change fixes issue https://github.com/swiftlang/swift-sdk-generator/issues/147.   Compared to https://github.com/swiftlang/swift-sdk-generator/pull/153, all the basic
'hello world' tests now pass.   The tests which import Foundation
still fail on all Swift 6.0 SDKs.

| SDK                                       | Hello World | Foundation |
| ----------------------------------------- | ----------- | ---------- |
| ubuntu_aarch64_5.9.2-RELEASE              | ok          | ok         |
| ubuntu_aarch64_5.9.2-RELEASE_with-docker  | ok          | ok         |
| ubuntu_aarch64_5.10.1-RELEASE             | ok          | ok         |
| ubuntu_aarch64_5.10.1-RELEASE_with-docker | ok          | ok         |
| ubuntu_aarch64_6.0.2-RELEASE              | ok          | FAIL2      |
| ubuntu_aarch64_6.0.2-RELEASE_with-docker  | ok          | FAIL2      |
|                                           |             |            |
| ubuntu_x86_64_5.9.2-RELEASE               | ok          | ok         |
| ubuntu_x86_64_5.9.2-RELEASE_with-docker   | ok          | ok         |
| ubuntu_x86_64_5.10.1-RELEASE              | ok          | ok         |
| ubuntu_x86_64_5.10.1-RELEASE_with-docker  | ok          | ok         |
| ubuntu_x86_64_6.0.2-RELEASE               | ok          | FAIL2      |
| ubuntu_x86_64_6.0.2-RELEASE_with-docker   | ok          | FAIL2      |
|                                           |             |            |
| rhel_aarch64_5.9.2-RELEASE_with-docker    | ok          | ok         |
| rhel_aarch64_5.10.1-RELEASE_with-docker   | ok          | ok         |
| rhel_aarch64_6.0.2-RELEASE_with-docker    | ok          | FAIL2      |
|                                           |             |            |
| rhel_x86_64_5.9.2-RELEASE_with-docker     | ok          | ok         |
| rhel_x86_64_5.10.1-RELEASE_with-docker    | ok          | ok         |
| rhel_x86_64_6.0.2-RELEASE_with-docker     | ok          | FAIL2      |


FAIL1: cannot find /lib/ld-linux-aarch64.so.1  (#147)
FAIL2: missing required module '_FoundationCShims'   (#152)

Fixes: https://github.com/swiftlang/swift-sdk-generator/issues/147
Depends on: #153 