### PR TITLE
generator/linux: Use the Swift 6.0 toolchain's lld

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -174,12 +174,18 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       engine,
       downloadableArtifacts: &downloadableArtifacts,
       itemsToDownload: { artifacts in
-        var items = [artifacts.hostLLVM]
+        var items: [DownloadableArtifacts.Item] = []
+
+        if !self.versionsConfiguration.swiftVersion.hasPrefix("6.0") {
+          items.append(artifacts.hostLLVM)
+        }
+
         switch self.targetSwiftSource {
         case .remoteTarball:
           items.append(artifacts.targetSwift)
         case .docker, .localPackage: break
         }
+
         switch self.hostSwiftSource {
         case .remoteTarball:
           items.append(artifacts.hostSwift)
@@ -234,7 +240,9 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       )
     }
 
-    try await generator.prepareLLDLinker(engine, llvmArtifact: downloadableArtifacts.hostLLVM)
+    if !self.versionsConfiguration.swiftVersion.hasPrefix("6.0") {
+      try await generator.prepareLLDLinker(engine, llvmArtifact: downloadableArtifacts.hostLLVM)
+    }
 
     try await generator.fixAbsoluteSymlinks(sdkDirPath: sdkDirPath)
 


### PR DESCRIPTION
After Swift 6.0 the swift.org toolchain includes LLD, so it is not
necessary to install it separately from an LLVM archive.   The LLD
provided by the swift.org toolchain is also a multiarch binary, so
the SDK will run on both x86_64 and aarch64 macOS hosts.

This change slightly reduces the size of a Swift 6.0 SDK because 
currently these SDKs include two copies of LLD - one from the SDK
and one from LLVM.   This is because LLD is typically installed as
a single binary with multiple symlinks pointing to it representing
different 'personalities' such as `ld.lld`, `wasm-ld` and so on.   SDK
generator copies the `lld` binary in as `ld.lld`, overwriting one of
the symlinks:

    -rwxr-xr-x   1 euanh  staff   108M 14 Nov  2023 ld.lld
    lrwxr-xr-x   1 euanh  staff     3B 24 Oct 15:11 ld64.lld -> lld
    -rwxr-xr-x   1 euanh  staff   265M 24 Oct 19:28 lld
    lrwxr-xr-x   1 euanh  staff     3B 24 Oct 15:11 lld-link -> lld
    lrwxr-xr-x   1 euanh  staff     3B 24 Oct 15:11 wasm-ld -> lld

After this PR, we only have one copy of the `lld` binary:

    lrwxr-xr-x   1 euanh  staff     3B 24 Oct 15:11 ld.lld -> lld
    lrwxr-xr-x   1 euanh  staff     3B 24 Oct 15:11 ld64.lld -> lld
    -rwxr-xr-x   1 euanh  staff   265M 24 Oct 19:28 lld
    lrwxr-xr-x   1 euanh  staff     3B 24 Oct 15:11 lld-link -> lld
    lrwxr-xr-x   1 euanh  staff     3B 24 Oct 15:11 wasm-ld -> lld

This change does not significantly change the time to build a new
SDK with a warm cache (PR #149), however the very first build with
a cold cache improves considerably because the LLVM archive does
not need to be downloaded and unpacked.

For example, two tests run one after the other on an M3 MacBook Air
with a fast network connection:

    rm -rf Artifacts Bundles
    swift run swift-sdk-generator make-linux-sdk --swift-version 6.0.2-RELEASE

`main`: 1m21s,     (2.9GB in `Artifacts` directory)
this PR: 39s,    (2.1GB in `Artifacts` directory)