### PR TITLE
generator/linux: copyTargetSwiftFromDocker does not need to call copyTargetSwift

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -97,7 +97,6 @@ extension SwiftSDKGenerator {
         try await generator.removeRecursively(at: sdkUsrLibPath.appending("python3.10"))
 
         try await generator.removeRecursively(at: sdkUsrLibPath.appending("ssl"))
-        try await generator.copyTargetSwift(from: sdkUsrPath, sdkDirPath: sdkDirPath)
       }
     }
   }


### PR DESCRIPTION
`copyTargetSwiftFromDocker()` already copies all the same files as `copyTargetSwift()`,
and puts them in the destination directory.   Calling `copyTargetSwift()` at the
end just results in several pointless rsync calls which sync the directories to
themselves.

Stopping in `copyTargetSwift()` shows that the source and destination arguments point to the same place:

    Process 77272 stopped
    * thread #2, queue = 'com.apple.root.default-qos.cooperative', stop reason = breakpoint 1.1 frame #0: ... at SwiftSDKGenerator+Copy.swift:105:8
       102      }
       103    }
       104
    -> 105    func copyTargetSwift(from distributionPath: FilePath, sdkDirPath: FilePath) async throws {
       106      logGenerationStep("Copying Swift core libraries for the target triple into Swift SDK bundle...")
       107
       108      for (pathWithinPackage, pathWithinSwiftSDK) in [
    Target 0: (swift-sdk-generator) stopped.
    (lldb) print distributionPath.string
    (String) ".../ubuntu-jammy.sdk/usr"
    (lldb) print sdkDirPath.string
    (String) ".../ubuntu-jammy.sdk"

The first rsync command line is then:

    rsync -a .../ubuntu-jammy.sdk/usr/lib/swift .../ubuntu-jammy.sdk/usr/lib

Removing the call to copyTargetSwift() does not save much time because rsync does not do much work, however disentangling the Ubuntu-based SDK build from the container-based build makes it easier to refactor both of them independently.

Diffing SDKs built before and after this change shows them to be identical. The EndToEndTests (which currently can't be run by CI) continue to pass locally.