### PR TITLE
generator/linux: Exclude more unneeded platforms from the toolchain

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -15,12 +15,15 @@ import Helpers
 import struct SystemPackage.FilePath
 
 let unusedDarwinPlatforms = [
-  "watchsimulator",
-  "iphonesimulator",
-  "appletvsimulator",
-  "iphoneos",
-  "watchos",
   "appletvos",
+  "appletvsimulator",
+  "embedded",
+  "iphoneos",
+  "iphonesimulator",
+  "watchos",
+  "watchsimulator",
+  "xros",
+  "xrsimulator",
 ]
 
 let unusedHostBinaries = [
@@ -28,6 +31,7 @@ let unusedHostBinaries = [
   "docc",
   "dsymutil",
   "sourcekit-lsp",
+  "swift-format",
   "swift-package",
   "swift-package-collection",
 ]


### PR DESCRIPTION
These changes reduce the size of the SDK by 450MB.   Not having
to extract and copy this data around slightly speeds up the process
of building an SDK.  On my machine

* Building a Swift 6.0 aarch64 SDK decreased from 23s to 22s
* Running the EndToEndTests decreased from 32m39s to 32m17s

The EndToEndTests continue to pass after this change.