### PR TITLE
generator: Silence extension conformance warning

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -61,8 +61,8 @@ struct GeneratorCLI: AsyncParsableCommand {
   }
 }
 
-extension Triple.Arch: ExpressibleByArgument {}
-extension Triple: ExpressibleByArgument {
+extension Triple.Arch: ArgumentParser.ExpressibleByArgument {}
+extension Triple: ArgumentParser.ExpressibleByArgument {
   public init?(argument: String) {
     self.init(argument, normalizing: false)
   }


### PR DESCRIPTION
Swift 6.0 complains:

    warning: extension declares a conformance of imported type
    'Triple' to imported protocol 'ExpressibleByArgument'

This warning can be silenced by qualifying the names:

    https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md#source-compatibility

Testing:
* Builds with Swift 5.8, 5.9 and 6.0
* EndToEndTests continue to pass locally.