### PR TITLE
Build Swift SDKs for a Linux host if the `--host` parameter matches a Linux OS (`*-unknown-linux-gnu`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-/.build
+.build*
 /.index-build
 /Packages
 /*.xcodeproj

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "16f7e62c08c6969899ce6cc277041e868364e5cf",
-        "version" : "1.19.0"
+        "revision" : "2119f0d9cc1b334e25447fe43d3693c0e60e6234",
+        "version" : "1.24.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
       }
     },
     {
@@ -16,6 +25,15 @@
       "state" : {
         "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
+        "version" : "1.3.0"
       }
     },
     {
@@ -41,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {
@@ -50,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "b51f1d6845b353a2121de1c6a670738ec33561a6",
-        "version" : "3.1.0"
+        "revision" : "ff0f781cf7c6a22d52957e50b104f5768b50c779",
+        "version" : "3.10.0"
       }
     },
     {
@@ -59,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
-        "revision" : "12358d55a3824bd5fed310b999ea8cf83a9a1a65",
-        "version" : "1.0.3"
+        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
+        "version" : "1.3.1"
       }
     },
     {
@@ -68,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
-        "version" : "1.6.1"
+        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
+        "version" : "1.6.2"
       }
     },
     {
@@ -77,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "4c4453b489cf76e6b3b0f300aba663eb78182fad",
-        "version" : "2.70.0"
+        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
+        "version" : "2.77.0"
       }
     },
     {
@@ -86,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "363da63c1966405764f380c627409b2f9d9e710b",
-        "version" : "1.21.0"
+        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
+        "version" : "1.24.1"
       }
     },
     {
@@ -95,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
-        "version" : "1.30.0"
+        "revision" : "170f4ca06b6a9c57b811293cebcb96e81b661310",
+        "version" : "1.35.0"
       }
     },
     {
@@ -104,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "4fb7ead803e38949eb1d6fabb849206a72c580f3",
-        "version" : "2.23.0"
+        "revision" : "c7e95421334b1068490b5d41314a50e70bab23d1",
+        "version" : "2.29.0"
       }
     },
     {
@@ -113,8 +131,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
-        "version" : "1.19.0"
+        "revision" : "bbd5e63cf949b7db0c9edaf7a21e141c52afe214",
+        "version" : "1.23.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
       }
     },
     {
@@ -122,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
-        "version" : "1.3.2"
+        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
+        "version" : "1.4.0"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -37,13 +37,16 @@ Linux distributions officially supported by the Swift project.
 | -:             | :-                        | :-                          |
 | macOS (arm64)  | ✅ macOS 13.0+            | ❌                         |
 | macOS (x86_64) | ✅ macOS 13.0+[^1]        | ❌                         |
-| Ubuntu         | ⚠️ (WIP)                  | ✅ 20.04 / 22.04           |
-| RHEL           | ⚠️ (WIP)                  | ✅ UBI 9                   |
-
+| Ubuntu         | ✅ 20.04+                 | ✅ 20.04 / 22.04           |
+| RHEL           | ✅ Fedora 39[^2], UBI 9   | ✅ UBI 9                   |
+| Amazon Linux 2 | ✅ Supported              | ✅ Supported[^3]           |
+| Debian 12      | ✅ Supported[^2]          | ✅ Supported[^2][^3]       |
 
 [^1]: Since LLVM project doesn't provide pre-built binaries of `lld` for macOS on x86_64, it will be automatically built
 from sources by the generator, which will increase its run by at least 15 minutes on recent hardware. You will also
 need CMake and Ninja preinstalled (e.g. via `brew install cmake ninja`).
+[^2]: These distributions are only supported by Swift 5.10.1 and later on both the host and target.
+[^3]: These versions are technically supported but require custom commands and a Docker container to build the Swift SDK, as the generator will not download dependencies for these distributions automatically. See [issue 138](https://github.com/swiftlang/swift-sdk-generator/issues/138).
 
 ## How to use it
 

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -53,10 +53,11 @@ struct DownloadableArtifacts: Sendable {
 
     if hostTriple.os == .linux {
       // Amazon Linux 2 is chosen for its best compatibility with all Swift-supported Linux hosts
+      let linuxArchSuffix = hostTriple.arch == .aarch64 ? "-\(Triple.Arch.aarch64.linuxConventionName)" : ""
       self.hostSwift = .init(
         remoteURL: versions.swiftDownloadURL(
-          subdirectory: "amazonlinux2",
-          platform: "amazonlinux2",
+          subdirectory: "amazonlinux2\(linuxArchSuffix)",
+          platform: "amazonlinux2\(linuxArchSuffix)",
           fileExtension: "tar.gz"
         ),
         localPath: paths.artifactsCachePath

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -51,16 +51,30 @@ struct DownloadableArtifacts: Sendable {
     self.versions = versions
     self.paths = paths
 
-    self.hostSwift = .init(
-      remoteURL: versions.swiftDownloadURL(
-        subdirectory: "xcode",
-        platform: "osx",
-        fileExtension: "pkg"
-      ),
-      localPath: paths.artifactsCachePath
-        .appending("host_swift_\(versions.swiftVersion)_\(hostTriple.triple).pkg"),
-      isPrebuilt: true
-    )
+    if hostTriple.os == .linux {
+      // Amazon Linux 2 is chosen for its best compatibility with all Swift-supported Linux hosts
+      self.hostSwift = .init(
+        remoteURL: versions.swiftDownloadURL(
+          subdirectory: "amazonlinux2",
+          platform: "amazonlinux2",
+          fileExtension: "tar.gz"
+        ),
+        localPath: paths.artifactsCachePath
+          .appending("host_swift_\(versions.swiftVersion)_\(hostTriple.triple).tar.gz"),
+        isPrebuilt: true
+      )
+    } else {
+      self.hostSwift = .init(
+        remoteURL: versions.swiftDownloadURL(
+          subdirectory: "xcode",
+          platform: "osx",
+          fileExtension: "pkg"
+        ),
+        localPath: paths.artifactsCachePath
+          .appending("host_swift_\(versions.swiftVersion)_\(hostTriple.triple).pkg"),
+        isPrebuilt: true
+      )
+    }
 
     self.hostLLVM = .init(
       remoteURL: URL(

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -114,6 +114,7 @@ extension SwiftSDKGenerator {
       report(downloadedFiles: downloadedFiles)
 
       for fileName in urls.map(\.lastPathComponent) {
+        print("Extracting \(fileName)...")
         try await fs.unpack(file: tmpDir.appending(fileName), into: sdkDirPath)
       }
     }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
@@ -49,9 +49,13 @@ extension SwiftSDKGenerator {
   }
 
   func symlinkClangHeaders() throws {
-    try self.createSymlink(
-      at: self.pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static/clang"),
-      pointingTo: "../swift/clang"
-    )
+    let swiftStaticClangPath = self.pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static/clang")
+    if !doesFileExist(at: swiftStaticClangPath) {
+      logGenerationStep("Symlinking clang headers...")
+      try self.createSymlink(
+        at: self.pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static/clang"),
+        pointingTo: "../swift/clang"
+      )
+    }
   }
 }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -253,7 +253,9 @@ public actor SwiftSDKGenerator {
     let isVerbose = self.isVerbose
     try await self.inTemporaryDirectory { _, tmp in
       try await Shell.run(#"cd "\#(tmp)" && ar -x "\#(debFile)""#, shouldLogCommands: isVerbose)
-      try await print(Shell.readStdout("ls \(tmp)"))
+      if isVerbose {
+        try await print(Shell.readStdout("ls \(tmp)"))
+      }
 
       try await Shell.run(
         #"tar -C "\#(directoryPath)" -xf "\#(tmp)"/data.tar.*"#,

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -164,7 +164,9 @@ public struct LinuxRecipe: SwiftSDKRecipe {
 
   func itemsToDownload(from artifacts: DownloadableArtifacts) -> [DownloadableArtifacts.Item] {
     var items: [DownloadableArtifacts.Item] = []
-    if self.hostSwiftSource != .preinstalled && !self.versionsConfiguration.swiftVersion.hasPrefix("6.0") {
+    if self.hostSwiftSource != .preinstalled
+      && self.mainHostTriple.os != .linux
+      && !self.versionsConfiguration.swiftVersion.hasPrefix("6.0") {
       items.append(artifacts.hostLLVM)
     }
 
@@ -279,12 +281,12 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     try await generator.fixAbsoluteSymlinks(sdkDirPath: sdkDirPath)
 
     if self.hostSwiftSource != .preinstalled {
-      if !self.versionsConfiguration.swiftVersion.hasPrefix("6.0") {
+      if self.mainHostTriple.os != .linux && !self.versionsConfiguration.swiftVersion.hasPrefix("6.0") {
         try await generator.prepareLLDLinker(engine, llvmArtifact: downloadableArtifacts.hostLLVM)
       }
 
       if self.versionsConfiguration.swiftVersion.hasPrefix("5.9") ||
-          self.versionsConfiguration.swiftVersion .hasPrefix("5.10") {
+          self.versionsConfiguration.swiftVersion.hasPrefix("5.10") {
         try await generator.symlinkClangHeaders()
       }
 

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -115,7 +115,7 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
       }()
       try await generator.removeToolchainComponents(
         pathsConfiguration.toolchainDirPath,
-        platforms: unusedDarwinPlatforms + ["embedded"],
+        platforms: unusedTargetPlatforms,
         libraries: unusedHostLibraries + liblldbNames,
         binaries: unusedHostBinaries + ["lldb", "lldb-argdumper", "lldb-server"]
       )

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -49,11 +49,8 @@ extension FileManager {
   }
 }
 
-// Building an SDK requires running the sdk-generator with `swift run swift-sdk-generator`.
-// This takes a lock on `.build`, but if the tests are being run by `swift test` the outer Swift Package Manager
-// instance will already hold this lock, causing the test to deadlock.   We can work around this by giving
-// the `swift run swift-sdk-generator` instance its own scratch directory.
-func buildSDK(_ logger: Logger, scratchPath: String, withArguments runArguments: String) async throws -> String {
+// This will build and run the generator in a separate .build directory from the main one
+func buildSDK(_ logger: Logger, scratchPath: String = ".build", withArguments runArguments: String) async throws -> String {
   var logger = logger
   logger[metadataKey: "runArguments"] = "\"\(runArguments)\""
   logger[metadataKey: "scratchPath"] = "\(scratchPath)"
@@ -230,9 +227,7 @@ func buildTestcases(config: SDKConfiguration) async throws {
     }
   }
 
-  let bundleName = try await FileManager.default.withTemporaryDirectory(logger: logger) { tempDir in
-    try await buildSDK(logger, scratchPath: tempDir.path, withArguments: config.sdkGeneratorArguments)
-  }
+  let bundleName = try await buildSDK(logger, withArguments: config.sdkGeneratorArguments)
 
   logger.info("Built SDK")
 

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -236,6 +236,10 @@ func buildTestcases(config: SDKConfiguration) async throws {
       try await buildTestcase(logger, testcase: testcase, bundleName: bundleName, tempDir: tempDir)
     }
   }
+
+  // Cleanup
+  logger.info("Removing SDK to cleanup...")
+  try await Shell.run("swift experimental-sdk remove \(bundleName)")
 }
 
 final class Swift59_UbuntuEndToEndTests: XCTestCase {


### PR DESCRIPTION
This fixes #114 and provides the following:

 - If the `--host` param or auto-detected `hostTriple.os` is `.linux`, the amazonlinux2 Swift toolchain is downloaded and included in the Swift SDK. Examples:
```
swift run swift-sdk-generator make-linux-sdk --swift-version 6.0.3-RELEASE --host x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu
swift run swift-sdk-generator make-linux-sdk --swift-version 5.10.1-RELEASE --host aarch64-unknown-linux-gnu --target x86_64-unknown-linux-gnu
```
 - I chose `amazonlinux2` for the host toolchain as it seems to be compatible with *every* Swift-supported Linux distribution with glibc versions and included libraries.
 - Updated logging for processing deb artifacts to print the names of the deb file being extracted:
```
Extracting libc6_2.35-0ubuntu3.8_arm64.deb...
Extracting libc6-dev_2.35-0ubuntu3.8_arm64.deb...
Extracting libgcc-s1_12.3.0-1ubuntu1~22.04_arm64.deb...
Extracting libgcc-12-dev_12.3.0-1ubuntu1~22.04_arm64.deb...
Extracting libicu70_70.1-2_arm64.deb...
Extracting libicu-dev_70.1-2_arm64.deb...
Extracting libstdc++-12-dev_12.3.0-1ubuntu1~22.04_arm64.deb...
Extracting libstdc++6_12.3.0-1ubuntu1~22.04_arm64.deb...
Extracting linux-libc-dev_5.15.0-130.140_arm64.deb...
Extracting zlib1g_1.2.11.dfsg-2ubuntu9.2_arm64.deb...
Extracting zlib1g-dev_1.2.11.dfsg-2ubuntu9.2_arm64.deb...
```
 - Updated dependencies for the swift-sdk-generator to fix compilation on Ubuntu 24.04.

For testing all of this, I updated the EndToEndTests:

 - If the`SWIFT_SDK_GENERATOR_TEST_LINUX_SWIFT_SDKS` env variable is defined, Swift SDKs are built for a Linux host with the arch matching the machine on which the tests are running. So on an M-series Mac, the triple `aarch64-unknown-linux-gnu` is used. Or on an Intel Mac or PC, then `x86_64-unknown-linux-gnu` is used as the `--host` triple.
 -  When Linux Swift SDKs are being tested, then a matrix of Swift docker containers are run against each test case to ensure the SDK works on every Linux distribution:
 ```
 [SwiftSDKGeneratorTests] Creating test project /tmp/FDFD488C-089B-4213-B927-0DE0F9BD6B3A/swift-sdk-generator-test
[SwiftSDKGeneratorTests] Updating minimum swift-tools-version in test project...
[SwiftSDKGeneratorTests] Building test project in 6.0-focal container
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-focal container with static-swift-stdlib
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-jammy container
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-jammy container with static-swift-stdlib
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-noble container
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-noble container with static-swift-stdlib
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-fedora39 container
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-fedora39 container with static-swift-stdlib
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-rhel-ubi9 container
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-rhel-ubi9 container with static-swift-stdlib
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-amazonlinux2 container
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-amazonlinux2 container with static-swift-stdlib
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-bookworm container
[SwiftSDKGeneratorTests] Test project built successfully
[SwiftSDKGeneratorTests] Building test project in 6.0-bookworm container with static-swift-stdlib
[SwiftSDKGeneratorTests] Test project built successfully
 ```

I do have a few thoughts/questions:

- Now we can generate Swift SDKs that work for Linux hosts, or any host, but there is no way to denote this in the SDK name. Should we consider adding some annotation to the end to show what hosts are compatible?
   - `-linux-x86_64`
   - `-linux-aarch64`
   - `-macos`
   - `-all`
- Do we need some unit testing for this stuff, or would the EndToEndTests changes be sufficient to cover this new functionality?