### PR TITLE
generator: Sort keys in JSON metadata files

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -16,7 +16,7 @@ import class Foundation.JSONEncoder
 
 private let encoder: JSONEncoder = {
   let encoder = JSONEncoder()
-  encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
+  encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes, .sortedKeys]
   return encoder
 }()
 


### PR DESCRIPTION
This change makes it possible to compare generated SDKs using recursive diff, without having to account for spurious differences cause by the order of keys in JSON metadata files.