### PR TITLE
generator: Add an environment variable to choose the container runtime

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -18,7 +18,7 @@ extension SwiftSDKGenerator {
     baseDockerImage: String,
     sdkDirPath: FilePath
   ) async throws {
-    logGenerationStep("Launching a Docker container to copy Swift SDK for the target triple from it...")
+    logGenerationStep("Launching a container to extract the Swift SDK for the target triple...")
     try await withDockerContainer(fromImage: baseDockerImage) { containerID in
       try await inTemporaryDirectory { generator, _ in
         let sdkUsrPath = sdkDirPath.appending("usr")

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -60,7 +60,7 @@ public actor SwiftSDKGenerator {
   }
 
   private let fileManager = FileManager.default
-  private static let dockerCommand = "docker"
+  private static let dockerCommand = ProcessInfo.processInfo.environment["SWIFT_SDK_GENERATOR_CONTAINER_RUNTIME"] ?? "docker"
 
   public static func getCurrentTriple(isVerbose: Bool) throws -> Triple {
     let current = UnixName.current!


### PR DESCRIPTION
There are now many alternative container runtimes.   These often expose a socket interface which is compatible with the `docker` CLI, but may also have their own command line utilities.   For our limited requirements, these alternative CLIs are often compatible enough with the `docker` CLI that we can use them directly.

This PR adds an environment variable to allow users running alternative container runtimes to use their CLIs directly when building SDKs, removing the need to have the `docker` CLI tools installed as well.   I've tested the generator with `podman`; it produced identical SDKs to the current implementation (#171), with good performance.

The `docker` CLI is currently still required to run the SDK generator tests.