### PR TITLE
generator: Do not include the host toolchain by default

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -115,7 +115,7 @@ extension GeneratorCLI {
       but requires exactly the same version of the swift.org toolchain to be installed for it to work.
       """
     )
-    var hostToolchain: Bool = true
+    var hostToolchain: Bool = false
 
     @Option(
       help: """


### PR DESCRIPTION
Not including the host toolchain matches the Swift Static Linux SDK.  Users with experience of the static SDK will be familiar with the need to install a matching OSS toolchain to use it:

   https://www.swift.org/documentation/articles/static-linux-getting-started.html#installing-the-sdk

Not including the host toolchain reduces the size of the SDK
bundle by about 2GB.   This makes SDKs easier to move around,
wastes less storage space if multiple SDKs are installed, and
speeds up the SDK build process - especially the first build,
as the host toolchain does not have to be downloaded.

Wasm SDKs also do not include the host toolchain.