### PR TITLE
generator: --from-container-image implies --with-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ swift run swift-sdk-generator make-linux-sdk --with-docker --linux-distribution-
 You can also specify the base container image by name:
 
 ```
-swift run swift-sdk-generator make-linux-sdk --with-docker --from-container-image swift:5.9-jammy
+swift run swift-sdk-generator make-linux-sdk --from-container-image swift:5.9-jammy
 ```
 
 ```

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -66,7 +66,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     if let targetSwiftPackagePath {
       targetSwiftSource = .localPackage(FilePath(targetSwiftPackagePath))
     } else {
-      if withDocker {
+      if withDocker || fromContainerImage != nil {
         let imageName = fromContainerImage ?? versionsConfiguration.swiftBaseDockerImage
         targetSwiftSource = .docker(baseSwiftDockerImage: imageName)
       } else {


### PR DESCRIPTION
If --from-container-image is specified without --with-docker, the generator builds an SDK from Debian packages, completely ignoring the user's clear intent to build from a container image.

For now, we can assume that a user who specifies --from-container-image also wants to use a container runtime.  In future we might be able to support extracting container images without the need for a
runtime.   If that happens, we can stop assuming --with-docker
and commands which only specify --from-container-image will continue
to work, so scripts and documentation won't need to be changed.