### PR TITLE
tests: End to end tests still require host toolchains

### DIFF
--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -124,7 +124,7 @@ final class RepeatedBuildTests: XCTestCase {
 
     // Test that an existing SDK can be rebuilt without cleaning up.
     // Test with no arguments by default:
-    var possibleArguments = [""]
+    var possibleArguments = ["--host-toolchain"]
     do {
       try await Shell.run("docker ps")
       possibleArguments.append("--with-docker --linux-distribution-name rhel --linux-distribution-version ubi9")
@@ -176,6 +176,7 @@ struct SDKConfiguration {
   var sdkGeneratorArguments: String {
     return [
       "--sdk-name \(bundleName)",
+      "--host-toolchain",
       withDocker ? "--with-docker" : nil,
       "--swift-version \(swiftVersion)-RELEASE",
       testLinuxSwiftSDKs ? "--host \(hostArch!)-unknown-linux-gnu" : nil,


### PR DESCRIPTION
The end to end tests still assume that the host toolchain will be
embedded in the SDK.   There is currently no provision in the test
harness for installing a toolchain before running the tests, so for
now we must use the --host-toolchain flag when building SDKs.