### PR TITLE
generator: Do not attempt to download toolchain if it is not needed

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -224,12 +224,14 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       generator.pathsConfiguration
     )
 
-    try await generator.downloadArtifacts(
-      client,
-      engine,
-      downloadableArtifacts: &downloadableArtifacts,
-      itemsToDownload: { artifacts in itemsToDownload(from: artifacts) }
-    )
+    if hostSwiftSource != .preinstalled {
+        try await generator.downloadArtifacts(
+          client,
+          engine,
+          downloadableArtifacts: &downloadableArtifacts,
+          itemsToDownload: { artifacts in itemsToDownload(from: artifacts) }
+        )
+    }
 
     if !self.shouldUseDocker {
       guard case let .ubuntu(version) = linuxDistribution else {


### PR DESCRIPTION
SDKs now do not include the host toolchain by default, but the generator still checks for host toolchains before deciding it does not need to download them.

Skipping this check when a host toolchain is not requested removes the
unnecessary  network request.    This saves a couple of seconds but also
makes it possible to run the generator offline, if building from a container
image which is already available locally.