### PR TITLE
generator: Quote paths passed to container image extraction commands

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -59,14 +59,14 @@ extension SwiftSDKGenerator {
     if hostSwiftPackagePath.string.contains("tar.gz") {
       try await Shell.run(
         #"""
-        tar -xzf \#(hostSwiftPackagePath) -C "\#(pathsConfiguration.toolchainDirPath)" -x \#(excludes.joined(separator: " ")) --strip-components=1
+        tar -xzf "\#(hostSwiftPackagePath)" -C "\#(pathsConfiguration.toolchainDirPath)" -x \#(excludes.joined(separator: " ")) --strip-components=1
         """#,
         shouldLogCommands: isVerbose
       )
     } else {
       try await Shell.run(
         #"""
-        tar -x --to-stdout -f \#(hostSwiftPackagePath) \*.pkg/Payload |
+        tar -x --to-stdout -f "\#(hostSwiftPackagePath)" \*.pkg/Payload |
         tar -C "\#(pathsConfiguration.toolchainDirPath)" -x \#(excludes.joined(separator: " ")) --include usr
         """#,
         shouldLogCommands: isVerbose

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -118,7 +118,7 @@ public actor SwiftSDKGenerator {
       else { return }
     }
     try await Shell.run(
-      "\(Self.dockerCommand) cp \(id):\(containerPath) - | tar x -C \(localPath.removingLastComponent())",
+      #"\#(Self.dockerCommand) cp \#(id):\#(containerPath) - | tar x -C "\#(localPath.removingLastComponent())""#,
       shouldLogCommands: self.isVerbose
     )
   }


### PR DESCRIPTION
Some paths were being passed to container extraction commands (tar, docker cp) without quotes.  This caused the extraction to fail if the paths contained spaces.