### PR TITLE
tests: Final SDK generator output should be printed to standard output

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -61,9 +61,8 @@ public extension SwiftSDKGenerator {
         try await generateArtifactBundleManifest(hostTriples: swiftSDKProduct.hostTriples)
 
         // Extra spaces added for readability for the user
-        logger.info(
+        print(
           """
-
 
           All done! Install the newly generated SDK with this command:
           swift experimental-sdk install \(pathsConfiguration.artifactBundlePath)


### PR DESCRIPTION
All SDK generator log messages are now printed as structured logs
via a logger instance.   This includes the final message which tells
the user how to install and use the SDK.   All logger messages are
printed to standard error by default.

This PR changes the final installation message back to an ordinary
print, which will go to standard output.   This means that the user
will still see this message even if standard error is redirected.
It also fixes the end to end tests, which were failing because they
look for the bundle path from the generator's standard output.