### PR TITLE
Generate SDKSettings.json file for Swift SDKs for Swift 5.9-6.0

### DIFF
--- a/Sources/SwiftSDKGenerator/Extensions/String+hasPrefixIn.swift
+++ b/Sources/SwiftSDKGenerator/Extensions/String+hasPrefixIn.swift
@@ -1,0 +1,10 @@
+extension String {
+    func hasPrefix(in array: [String]) -> Bool {
+        for item in array {
+            if self.hasPrefix(item) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -112,4 +112,35 @@ extension SwiftSDKGenerator {
       )
     )
   }
+
+  struct SDKSettings: Codable {
+    var DisplayName: String
+    var Version: String = "0.0.1"
+    var VersionMap: [String: String] = [:]
+    var CanonicalName: String
+  }
+
+  /// Generates an `SDKSettings.json` file that looks like this:
+  /// 
+  /// ```json
+  /// {
+  ///   "CanonicalName" : "<arch>-swift-linux-[gnu|gnueabihf]",
+  ///   "DisplayName" : "Swift SDK for <distribution> (<arch>)",
+  ///   "Version" : "0.0.1",
+  ///   "VersionMap" : {
+  ///
+  ///   }
+  /// }
+  /// ```
+  func generateSDKSettingsFile(sdkDirPath: FilePath, distribution: LinuxDistribution) throws {
+    logger.info("Generating SDKSettings.json file to silence cross-compilation warnings...")
+
+    let sdkSettings = SDKSettings(
+      DisplayName: "Swift SDK for \(distribution) (\(targetTriple.archName))",
+      CanonicalName: targetTriple.triple.replacingOccurrences(of: "unknown", with: "swift")
+    )
+
+    let sdkSettingsFilePath = sdkDirPath.appending("SDKSettings.json")
+    try writeFile(at: sdkSettingsFilePath, encoder.encode(sdkSettings))
+  }
 }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -195,8 +195,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     if self.hostSwiftSource == .preinstalled {
       // Swift 5.9 and 5.10 require `supportedTriples` to be set in info.json.
       // FIXME: This can be removed once the SDK generator does not support 5.9/5.10 any more.
-      if self.versionsConfiguration.swiftVersion.hasPrefix("5.9")
-          || self.versionsConfiguration.swiftVersion.hasPrefix("5.10") {
+      if self.versionsConfiguration.swiftVersion.hasPrefix(in: ["5.9", "5.10"]) {
         return [
           Triple("x86_64-unknown-linux-gnu"),
           Triple("aarch64-unknown-linux-gnu"),
@@ -297,8 +296,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
         try await generator.prepareLLDLinker(engine, llvmArtifact: downloadableArtifacts.hostLLVM)
       }
 
-      if self.versionsConfiguration.swiftVersion.hasPrefix("5.9") ||
-          self.versionsConfiguration.swiftVersion.hasPrefix("5.10") {
+      if self.versionsConfiguration.swiftVersion.hasPrefix(in: ["5.9", "5.10"]) {
         try await generator.symlinkClangHeaders()
       }
 

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -291,6 +291,12 @@ public struct LinuxRecipe: SwiftSDKRecipe {
 
     try await generator.fixAbsoluteSymlinks(sdkDirPath: sdkDirPath)
 
+    // Swift 6.1 and later do not throw warnings about the SDKSettings.json file missing,
+    // so they don't need this file.
+    if self.versionsConfiguration.swiftVersion.hasPrefix(in: ["5.9", "5.10", "6.0"]) {
+      try await generator.generateSDKSettingsFile(sdkDirPath: sdkDirPath, distribution: linuxDistribution)
+    }
+
     if self.hostSwiftSource != .preinstalled {
       if self.mainHostTriple.os != .linux && !self.versionsConfiguration.swiftVersion.hasPrefix("6.0") {
         try await generator.prepareLLDLinker(engine, llvmArtifact: downloadableArtifacts.hostLLVM)


### PR DESCRIPTION
I know that the warnings about the `SDKSettings.json` file were fixed in Swift 6.1 and later and that issue #110 was closed. However, we are still generating Swift SDKs for 5.9, 5.10, and 6.0 which all give the warnings. 

So, my suggestion is to generate this `SDKSettings.json` file for versions older than 6.1, similar to how the the Linux Static Swift SDKs do it. Here is the file that comes in the `swift-6.0.3-RELEASE_static-linux-0.0.1` Swift SDK for example:

```json
{
  "DisplayName": "Swift SDK for Statically Linked Linux (x86_64)",
  "Version": "0.0.1",
  "VersionMap": {},
  "CanonicalName": "x86_64-swift-linux-musl"
}
```

Taking inspiration from this, I am generating a similar file for Swift SDKs created by the generator:

```json
{
  "CanonicalName" : "x86_64-swift-linux-gnu",
  "DisplayName" : "Swift SDK for Ubuntu Jammy (x86_64)",
  "Version" : "0.0.1",
  "VersionMap" : {

  }
}
```

The ordering is not the same due to how `JSONEncoder()` sorts things, and the formatting is a little different too due to `.prettyPrinted`, but it works just the same. And, the "warning: Could not read SDKSettings.json for SDK at: <path>" warning is successfully suppressed.

This really is a minor change that is more "quality-of-life" then adding any functionality. But, not having those warnings printed when using the generated Swift SDKs are used is a nice to have.

@MaxDesiatov @euanh @kateinoigakukun 