### PR TITLE
Add support for generating Swift SDKs for Ubuntu 24.04 Noble

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The generator also allows cross-compiling between any Linux distributions offici
 | -:             | :-                        | :-                          |
 | macOS (arm64)  | ✅ macOS 13.0+            | ❌                         |
 | macOS (x86_64) | ✅ macOS 13.0+[^1]        | ❌                         |
-| Ubuntu         | ✅ 20.04+                 | ✅ 20.04 / 22.04           |
+| Ubuntu         | ✅ 20.04+                 | ✅ 20.04+                  |
 | RHEL           | ✅ Fedora 39[^2], UBI 9   | ✅ UBI 9                   |
 | Amazon Linux 2 | ✅ Supported              | ✅ Supported[^3]           |
 | Debian 12      | ✅ Supported[^2]          | ✅ Supported[^2][^3]       |

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -200,7 +200,7 @@ extension GeneratorCLI {
     @Option(
       help: """
       Version of the Linux distribution used as a target platform. Available options for Ubuntu: `20.04`, \
-      `22.04` (default when `--linux-distribution-name` is `ubuntu`). Available options for RHEL: `ubi9` (default when \
+      `22.04` (default when `--linux-distribution-name` is `ubuntu`), `24.04`. Available options for RHEL: `ubi9` (default when \
       `--linux-distribution-name` is `rhel`).
       """
     )

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -199,9 +199,9 @@ extension GeneratorCLI {
 
     @Option(
       help: """
-      Version of the Linux distribution used as a target platform. Available options for Ubuntu: `20.04`, \
-      `22.04` (default when `--linux-distribution-name` is `ubuntu`), `24.04`. Available options for RHEL: `ubi9` (default when \
-      `--linux-distribution-name` is `rhel`).
+      Version of the Linux distribution used as a target platform.
+      Available options for Ubuntu: `20.04`, `22.04` (default when `--linux-distribution-name` is `ubuntu`), `24.04`.
+      Available options for RHEL: `ubi9` (default when `--linux-distribution-name` is `rhel`).
       """
     )
     var linuxDistributionVersion: String?

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -202,7 +202,7 @@ extension HTTPClientProtocol {
     \(mirrorURL)/dists/\(ubuntuRelease)\(releaseSuffix)/\(repository)/binary-\(
       targetTriple.arch!
         .debianConventionName
-    )/Packages.gz
+    )/Packages.xz
     """
 
     guard let packages = try await downloadUbuntuPackagesList(

--- a/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
@@ -60,7 +60,6 @@ public enum LinuxDistribution: Hashable, Sendable {
           "linux-libc-dev",
           "zlib1g",
           "zlib1g-dev",
-          "libc6",
         ]
       case .jammy: return [
           "libc6",

--- a/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
@@ -10,10 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-private let ubuntuReleases = [
-  "22.04": "jammy",
-]
-
 public enum LinuxDistribution: Hashable, Sendable {
   public enum Name: String {
     case rhel
@@ -27,6 +23,7 @@ public enum LinuxDistribution: Hashable, Sendable {
   public enum Ubuntu: String, Sendable {
     case focal
     case jammy
+    case noble
 
     init(version: String) throws {
       switch version {
@@ -34,6 +31,8 @@ public enum LinuxDistribution: Hashable, Sendable {
         self = .focal
       case "22.04":
         self = .jammy
+      case "24.04":
+        self = .noble
       default:
         throw GeneratorError.unknownLinuxDistribution(name: LinuxDistribution.Name.ubuntu.rawValue, version: version)
       }
@@ -43,6 +42,7 @@ public enum LinuxDistribution: Hashable, Sendable {
       switch self {
       case .focal: return "20.04"
       case .jammy: return "22.04"
+      case .noble: return "24.04"
       }
     }
 
@@ -70,6 +70,19 @@ public enum LinuxDistribution: Hashable, Sendable {
           "libicu70",
           "libicu-dev",
           "libstdc++-12-dev",
+          "libstdc++6",
+          "linux-libc-dev",
+          "zlib1g",
+          "zlib1g-dev",
+        ]
+      case .noble: return [
+          "libc6",
+          "libc6-dev",
+          "libgcc-s1",
+          "libgcc-13-dev",
+          "libicu74",
+          "libicu-dev",
+          "libstdc++-13-dev",
           "libstdc++6",
           "linux-libc-dev",
           "zlib1g",

--- a/Sources/SwiftSDKGenerator/SystemUtils/ByteBuffer+Utils.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/ByteBuffer+Utils.swift
@@ -17,7 +17,7 @@ import NIOCore
 public extension ByteBuffer {
   func unzip(isVerbose: Bool) async throws -> ByteBuffer? {
     let result = try await ProcessExecutor.runCollectingOutput(
-      executable: "/usr/bin/gzip", ["-cd"],
+      executable: "/usr/bin/xz", ["-cd"],
       standardInput: [self].async,
       collectStandardOutput: true,
       collectStandardError: false,


### PR DESCRIPTION
I was working on adding Debian 12 support for #116, but realized that adding Ubuntu Noble is "low-hanging fruit", since it's very straightforward. The default is still Ubuntu 22.04 Jammy, but this adds the option of generating the Swift SDK for 24.04 Noble now.

```
swift run swift-sdk-generator make-linux-sdk --linux-distribution-version 24.04
```

I have also changed the packages download to get `Packages.xz` instead of `Packages.gz` since it is a smaller file download. I wonder if it is okay to use `xz` here since I noticed that the directories on the Debian mirrors only have `Packages.xz` files available, unlike the Ubuntu mirrors which all have `Packages.gz` AND `Packages.xz` files available.

@MaxDesiatov @euanh 