### PR TITLE
Fix missing lib/ directory in Ubuntu Noble SDK, remove unused toolchain components

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
@@ -16,6 +16,14 @@ import SystemPackage
 import struct Foundation.Data
 
 extension SwiftSDKGenerator {
+  func createLibSymlink(sdkDirPath: FilePath) throws {
+    let libPath = sdkDirPath.appending("lib")
+    if !doesFileExist(at: libPath) {
+      logger.info("Adding lib symlink to usr/lib...")
+      try createSymlink(at: libPath, pointingTo: "usr/lib")
+    }
+  }
+
   func fixAbsoluteSymlinks(sdkDirPath: FilePath) throws {
     logger.info("Fixing up absolute symlinks...")
 

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -289,6 +289,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       )
     }
 
+    try await generator.createLibSymlink(sdkDirPath: sdkDirPath)
     try await generator.fixAbsoluteSymlinks(sdkDirPath: sdkDirPath)
 
     // Swift 6.1 and later do not throw warnings about the SDKSettings.json file missing,

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -289,6 +289,14 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       )
     }
 
+    logger.info("Removing unused toolchain components from target SDK...")
+    try await generator.removeToolchainComponents(
+      sdkDirPath,
+      platforms: unusedTargetPlatforms,
+      libraries: unusedHostLibraries,
+      binaries: unusedHostBinaries
+    )
+
     try await generator.createLibSymlink(sdkDirPath: sdkDirPath)
     try await generator.fixAbsoluteSymlinks(sdkDirPath: sdkDirPath)
 

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -151,10 +151,11 @@ final class RepeatedBuildTests: XCTestCase {
 struct SDKConfiguration {
   var swiftVersion: String
   var linuxDistributionName: String
+  var linuxDistributionVersion: String
   var architecture: String
   var withDocker: Bool
 
-  var bundleName: String { "\(linuxDistributionName)_\(architecture)_\(swiftVersion)-RELEASE\(withDocker ? "_with-docker" : "")" }
+  var bundleName: String { "\(linuxDistributionName)_\(linuxDistributionVersion)_\(architecture)_\(swiftVersion)-RELEASE\(withDocker ? "_with-docker" : "")" }
 
   func withDocker(_ enabled: Bool = true) -> SDKConfiguration {
     var res = self
@@ -308,6 +309,7 @@ final class Swift59_UbuntuEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "5.9.2",
     linuxDistributionName: "ubuntu",
+    linuxDistributionVersion: "22.04",
     architecture: "aarch64",
     withDocker: false
   )
@@ -337,6 +339,7 @@ final class Swift510_UbuntuEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "5.10.1",
     linuxDistributionName: "ubuntu",
+    linuxDistributionVersion: "22.04",
     architecture: "aarch64",
     withDocker: false
   )
@@ -366,6 +369,7 @@ final class Swift60_UbuntuEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "6.0.3",
     linuxDistributionName: "ubuntu",
+    linuxDistributionVersion: "24.04",
     architecture: "aarch64",
     withDocker: false
   )
@@ -395,6 +399,7 @@ final class Swift59_RHELEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "5.9.2",
     linuxDistributionName: "rhel",
+    linuxDistributionVersion: "ubi9",
     architecture: "aarch64",
     withDocker: true  // RHEL-based SDKs can only be built from containers
   )
@@ -414,6 +419,7 @@ final class Swift510_RHELEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "5.10.1",
     linuxDistributionName: "rhel",
+    linuxDistributionVersion: "ubi9",
     architecture: "aarch64",
     withDocker: true  // RHEL-based SDKs can only be built from containers
   )
@@ -433,6 +439,7 @@ final class Swift60_RHELEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "6.0.3",
     linuxDistributionName: "rhel",
+    linuxDistributionVersion: "ubi9",
     architecture: "aarch64",
     withDocker: true  // RHEL-based SDKs can only be built from containers
   )


### PR DESCRIPTION
Apparently I didn't test very well from PR #188, because when I went to use the Ubuntu Noble Swift SDK, I got this error:

```
error: link command failed with exit code 1 (use -v to see invocation)
ld.lld: error: ~/.swiftpm/swift-sdks/6.0.3-RELEASE_ubuntu_noble_aarch64.artifactbundle/6.0.3-RELEASE_ubuntu_noble_aarch64/aarch64-unknown-linux-gnu/ubuntu-noble.sdk/usr/lib/aarch64-linux-gnu/libm.so:4: cannot find /lib/aarch64-linux-gnu/libm.so.6 inside ~/.swiftpm/swift-sdks/6.0.3-RELEASE_ubuntu_noble_aarch64/aarch64-unknown-linux-gnu/ubuntu-noble.sdk
>>> GROUP ( /lib/aarch64-linux-gnu/libm.so.6  AS_NEEDED ( /lib/aarch64-linux-gnu/libmvec.so.1 ) )
>>>         ^
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld.lld: error: ~/.swiftpm/swift-sdks/6.0.3-RELEASE_ubuntu_noble_aarch64.artifactbundle/6.0.3-RELEASE_ubuntu_noble_aarch64/aarch64-unknown-linux-gnu/ubuntu-noble.sdk/usr/lib/aarch64-linux-gnu/libm.so:4: cannot find /lib/aarch64-linux-gnu/libm.so.6 inside /~/.swiftpm/swift-sdks/6.0.3-RELEASE_ubuntu_noble_aarch64.artifactbundle/6.0.3-RELEASE_ubuntu_noble_aarch64/aarch64-unknown-linux-gnu/ubuntu-noble.sdk
>>> GROUP ( /lib/aarch64-linux-gnu/libm.so.6  AS_NEEDED ( /lib/aarch64-linux-gnu/libmvec.so.1 ) )
>>>         ^
```

Turns out, the packages for Ubuntu Noble do not come with a lib/ symlink included, so all I needed was to add a custom step to create that symlink from `ubuntu-noble.sdk/lib` -> `ubuntu-noble.sdk/usr/lib` and all is well.

As a part of these changes, I also added a missing cleanup of the target toolchain to remove unused parts as is done for the WASM recipe. Doing this reduces the `ubuntu-noble.sdk` from 1GB to 721MB, when building the Swift SDK without docker. This can help for the end-to-end tests, and is nice to have smaller Swift SDK distributions.

Finally, I updated the EndToEndTests to provide `linuxDistributionVersion` and set the Swift60_Ubuntu tests to use "24.04" as a way to test this lib/ directory fix. This has me thinking we may want to think about end-to-end tests for each version of Ubuntu, like "20.04", "22.04", and "24.04", for each version of Swift. What do you think @euanh ?