### PR TITLE
Fix support for building with `--static-swift-stdlib` for armv7

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -129,7 +129,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       swiftCompilerOptions.append("-use-ld=lld")
 
       // 32-bit architectures require libatomic
-      if targetTriple.archName == "armv7" {
+      if let arch = targetTriple.arch, arch.is32Bit {
         swiftCompilerOptions.append("-latomic")
       }
 

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -128,6 +128,11 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     } else {
       swiftCompilerOptions.append("-use-ld=lld")
 
+      // 32-bit architectures require libatomic
+      if targetTriple.archName == "armv7" {
+        swiftCompilerOptions.append("-latomic")
+      }
+
       if self.hostSwiftSource != .preinstalled {
         toolset.linker = Toolset.ToolProperties(path: "ld.lld")
       }

--- a/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/LinuxRecipeTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/LinuxRecipeTests.swift
@@ -45,6 +45,7 @@ final class LinuxRecipeTests: XCTestCase {
     let testCases = [
       (
         swiftVersion: "5.9.2",
+        targetTriple: Triple("x86_64-unknown-linux-gnu"),
         expectedSwiftCompilerOptions: [
           "-Xlinker", "-R/usr/lib/swift/linux/",
           "-Xclang-linker", "--ld-path=ld.lld"
@@ -53,9 +54,20 @@ final class LinuxRecipeTests: XCTestCase {
       ),
       (
         swiftVersion: "6.0.2",
+        targetTriple: Triple("aarch64-unknown-linux-gnu"),
         expectedSwiftCompilerOptions: [
           "-Xlinker", "-R/usr/lib/swift/linux/",
           "-use-ld=lld"
+        ],
+        expectedLinkerPath: "ld.lld"
+      ),
+      (
+        swiftVersion: "6.0.3",
+        targetTriple: Triple("armv7-unknown-linux-gnueabihf"),
+        expectedSwiftCompilerOptions: [
+          "-Xlinker", "-R/usr/lib/swift/linux/",
+          "-use-ld=lld",
+          "-latomic"
         ],
         expectedLinkerPath: "ld.lld"
       )
@@ -65,7 +77,7 @@ final class LinuxRecipeTests: XCTestCase {
       let recipe = try self.createRecipe(swiftVersion: testCase.swiftVersion)
       var toolset = Toolset(rootPath: nil)
       recipe.applyPlatformOptions(
-        toolset: &toolset, targetTriple: Triple("aarch64-unknown-linux-gnu")
+        toolset: &toolset, targetTriple: testCase.targetTriple
       )
       XCTAssertEqual(toolset.swiftCompiler?.extraCLIOptions, testCase.expectedSwiftCompilerOptions)
       XCTAssertEqual(toolset.linker?.path, testCase.expectedLinkerPath)


### PR DESCRIPTION
The [atomic library is used in the Swift stdlib](https://github.com/swiftlang/swift/blob/69756635819114a851023aa2e8e6fd87f51d094d/cmake/modules/AddSwift.cmake#L336-L338) for 32-bit architectures. As such, when attempting to compile a binary containing the static Swift stdlib using a Swift SDK for armv7, `-latomic` must be linked. This is not needed for regular cross-compilation, just when passing `--static-swift-stdlib`.

I've added `-latomic` for "armv7" and added a test case in `LinuxRecipeTests` to ensure that it is included in the toolset.json file.

Now, I can build my binary that contains the statically linked Swift stdlib with this command:

```
swift build --swift-sdk 6.0.3-RELEASE_debian_bookworm_armv7 --static-swift-stdlib
```

This generates a rather large binary when also linking other things such as Foundation and Dispatch, as is to be expected:

```
$ pwd
~/tmp/hummingbird-examples/hello
$ du -hs .build/debug/App
123M	.build/debug/App
```

But that's fine, because it works perfectly on the target (Raspberry Pi 2) and provides yet another option for compiling binaries using the Swift SDK.