### PR TITLE
Update defaults for Swift 6.1-RELEASE

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -113,7 +113,7 @@ extension GeneratorCLI {
     var swiftBranch: String? = nil
 
     @Option(help: "Version of Swift to supply in the bundle.")
-    var swiftVersion = "6.0.3-RELEASE"
+    var swiftVersion = "6.1-RELEASE"
 
     @Option(
       help: """

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -54,12 +54,12 @@ struct DownloadableArtifacts: Sendable {
 
     if hostTriple.os == .linux {
       // Amazon Linux 2 is chosen for its best compatibility with all Swift-supported Linux hosts
-      let linuxArchSuffix =
+      let hostArchSuffix =
         hostTriple.arch == .aarch64 ? "-\(Triple.Arch.aarch64.linuxConventionName)" : ""
       self.hostSwift = .init(
         remoteURL: versions.swiftDownloadURL(
-          subdirectory: "amazonlinux2\(linuxArchSuffix)",
-          platform: "amazonlinux2\(linuxArchSuffix)",
+          subdirectory: "amazonlinux2\(hostArchSuffix)",
+          platform: "amazonlinux2\(hostArchSuffix)",
           fileExtension: "tar.gz"
         ),
         localPath: paths.artifactsCachePath
@@ -97,7 +97,9 @@ struct DownloadableArtifacts: Sendable {
     self.targetSwift = .init(
       remoteURL: versions.swiftDownloadURL(),
       localPath: paths.artifactsCachePath
-        .appending("target_swift_\(versions.swiftVersion)_\(targetTriple.triple).tar.gz"),
+        .appending(
+          "target_swift_\(versions.swiftVersion)_\(versions.swiftPlatform)_\(targetTriple.archName).tar.gz"
+        ),
       isPrebuilt: true
     )
   }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -147,6 +147,17 @@ extension SwiftSDKGenerator {
         try await fs.unpack(file: tmpDir.appending(fileName), into: sdkDirPath)
       }
     }
+
+    // Make sure we have /lib and /lib64, and if not symlink from /usr
+    // This makes building from packages more consistent with copying from the Docker container
+    let libDirectories = ["lib", "lib64"]
+    for dir in libDirectories {
+      let sdkLibPath = sdkDirPath.appending(dir)
+      let sdkUsrLibPath = sdkDirPath.appending("usr/\(dir)")
+      if !doesFileExist(at: sdkLibPath) && doesFileExist(at: sdkUsrLibPath) {
+        try createSymlink(at: sdkLibPath, pointingTo: FilePath("./usr/\(dir)"))
+      }
+    }
   }
 
   func downloadFiles(

--- a/Sources/SwiftSDKGenerator/PlatformModels/VersionsConfiguration.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/VersionsConfiguration.swift
@@ -37,14 +37,19 @@ public struct VersionsConfiguration: Sendable {
   var swiftPlatform: String {
     switch self.linuxDistribution {
     case let .ubuntu(ubuntu):
-      return "ubuntu\(ubuntu.version)\(self.linuxArchSuffix)"
+      return "ubuntu\(ubuntu.version)"
     case let .rhel(rhel):
-      return "\(rhel.rawValue)\(self.linuxArchSuffix)"
+      return rhel.rawValue
     }
   }
 
+  var swiftPlatformAndSuffix: String {
+    return "\(self.swiftPlatform)\(self.linuxArchSuffix)"
+  }
+
   func swiftDistributionName(platform: String? = nil) -> String {
-    "swift-\(self.swiftVersion)-\(platform ?? self.swiftPlatform)"
+    return
+      "swift-\(self.swiftVersion)-\(platform ?? self.swiftPlatformAndSuffix)"
   }
 
   func swiftDownloadURL(
@@ -52,14 +57,10 @@ public struct VersionsConfiguration: Sendable {
     platform: String? = nil,
     fileExtension: String = "tar.gz"
   ) -> URL {
-    let computedSubdirectory: String
-    switch self.linuxDistribution {
-    case let .ubuntu(ubuntu):
-      computedSubdirectory =
-        "ubuntu\(ubuntu.version.replacingOccurrences(of: ".", with: ""))\(self.linuxArchSuffix)"
-    case let .rhel(rhel):
-      computedSubdirectory = rhel.rawValue
-    }
+    let computedPlatform = platform ?? self.swiftPlatformAndSuffix
+    let computedSubdirectory =
+      subdirectory
+      ?? computedPlatform.replacingOccurrences(of: ".", with: "")
 
     return URL(
       string: """

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -178,7 +178,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     var items: [DownloadableArtifacts.Item] = []
     if self.hostSwiftSource != .preinstalled
       && self.mainHostTriple.os != .linux
-      && !self.versionsConfiguration.swiftVersion.hasPrefix("6.0")
+      && !self.versionsConfiguration.swiftVersion.hasPrefix("6.")
     {
       items.append(artifacts.hostLLVM)
     }
@@ -319,7 +319,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
 
     if self.hostSwiftSource != .preinstalled {
       if self.mainHostTriple.os != .linux
-        && !self.versionsConfiguration.swiftVersion.hasPrefix("6.0")
+        && !self.versionsConfiguration.swiftVersion.hasPrefix("6.")
       {
         try await generator.prepareLLDLinker(engine, llvmArtifact: downloadableArtifacts.hostLLVM)
       }

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -185,6 +185,12 @@ struct SDKConfiguration {
     return res
   }
 
+  func withLinuxDistributionVersion(_ version: String) -> SDKConfiguration {
+    var res = self
+    res.linuxDistributionVersion = version
+    return res
+  }
+
   func withArchitecture(_ arch: String) -> SDKConfiguration {
     var res = self
     res.architecture = arch
@@ -474,6 +480,30 @@ final class Swift61_UbuntuEndToEndTests: XCTestCase {
   func testX86_64FromContainer() async throws {
     try skipSlow()
     try await buildTestcases(config: config.withArchitecture("x86_64").withDocker())
+  }
+
+  func testJammyAarch64Direct() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("aarch64").withLinuxDistributionVersion("22.04"))
+  }
+
+  func testJammyX86_64Direct() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("x86_64").withLinuxDistributionVersion("22.04"))
+  }
+
+  func testJammyAarch64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("aarch64").withLinuxDistributionVersion("22.04").withDocker())
+  }
+
+  func testJammyX86_64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("x86_64").withLinuxDistributionVersion("22.04").withDocker())
   }
 }
 

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -627,16 +627,4 @@ final class Swift61_RHELEndToEndTests: XCTestCase {
     try await buildTestcases(
       config: config.withArchitecture("x86_64").withContainerImageSuffix("amazonlinux2"))
   }
-
-  func testFedora39Aarch64FromContainer() async throws {
-    try skipSlow()
-    try await buildTestcases(
-      config: config.withArchitecture("aarch64").withContainerImageSuffix("fedora39"))
-  }
-
-  func testFedora39X86_64FromContainer() async throws {
-    try skipSlow()
-    try await buildTestcases(
-      config: config.withArchitecture("x86_64").withContainerImageSuffix("fedora39"))
-  }
 }

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -500,25 +500,29 @@ final class Swift61_UbuntuEndToEndTests: XCTestCase {
   func testJammyAarch64Direct() async throws {
     try skipSlow()
     try await buildTestcases(
-      config: config.withArchitecture("aarch64").withLinuxDistributionVersion("22.04"))
+      config: config.withArchitecture("aarch64").withLinuxDistributionVersion("22.04")
+    )
   }
 
   func testJammyX86_64Direct() async throws {
     try skipSlow()
     try await buildTestcases(
-      config: config.withArchitecture("x86_64").withLinuxDistributionVersion("22.04"))
+      config: config.withArchitecture("x86_64").withLinuxDistributionVersion("22.04")
+    )
   }
 
   func testJammyAarch64FromContainer() async throws {
     try skipSlow()
     try await buildTestcases(
-      config: config.withArchitecture("aarch64").withLinuxDistributionVersion("22.04").withDocker())
+      config: config.withArchitecture("aarch64").withLinuxDistributionVersion("22.04").withDocker()
+    )
   }
 
   func testJammyX86_64FromContainer() async throws {
     try skipSlow()
     try await buildTestcases(
-      config: config.withArchitecture("x86_64").withLinuxDistributionVersion("22.04").withDocker())
+      config: config.withArchitecture("x86_64").withLinuxDistributionVersion("22.04").withDocker()
+    )
   }
 }
 
@@ -674,12 +678,14 @@ final class Swift61_RHELEndToEndTests: XCTestCase {
   func testAmazonLinux2Aarch64FromContainer() async throws {
     try skipSlow()
     try await buildTestcases(
-      config: config.withArchitecture("aarch64").withContainerImageSuffix("amazonlinux2"))
+      config: config.withArchitecture("aarch64").withContainerImageSuffix("amazonlinux2")
+    )
   }
 
   func testAmazonLinux2X86_64FromContainer() async throws {
     try skipSlow()
     try await buildTestcases(
-      config: config.withArchitecture("x86_64").withContainerImageSuffix("amazonlinux2"))
+      config: config.withArchitecture("x86_64").withContainerImageSuffix("amazonlinux2")
+    )
   }
 }

--- a/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/EndToEndTests.swift
@@ -447,6 +447,36 @@ final class Swift60_UbuntuEndToEndTests: XCTestCase {
   }
 }
 
+final class Swift61_UbuntuEndToEndTests: XCTestCase {
+  let config = SDKConfiguration(
+    swiftVersion: "6.1",
+    linuxDistributionName: "ubuntu",
+    linuxDistributionVersion: "24.04",
+    architecture: "aarch64",
+    withDocker: false
+  )
+
+  func testAarch64Direct() async throws {
+    try skipSlow()
+    try await buildTestcases(config: config.withArchitecture("aarch64"))
+  }
+
+  func testX86_64Direct() async throws {
+    try skipSlow()
+    try await buildTestcases(config: config.withArchitecture("x86_64"))
+  }
+
+  func testAarch64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(config: config.withArchitecture("aarch64").withDocker())
+  }
+
+  func testX86_64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(config: config.withArchitecture("x86_64").withDocker())
+  }
+}
+
 final class Swift59_RHELEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "5.9.2",
@@ -526,6 +556,50 @@ final class Swift510_RHELEndToEndTests: XCTestCase {
 final class Swift60_RHELEndToEndTests: XCTestCase {
   let config = SDKConfiguration(
     swiftVersion: "6.0.3",
+    linuxDistributionName: "rhel",
+    linuxDistributionVersion: "ubi9",
+    architecture: "aarch64",
+    withDocker: true  // RHEL-based SDKs can only be built from containers
+  )
+
+  func testAarch64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(config: config.withArchitecture("aarch64"))
+  }
+
+  func testX86_64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(config: config.withArchitecture("x86_64"))
+  }
+
+  func testAmazonLinux2Aarch64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("aarch64").withContainerImageSuffix("amazonlinux2"))
+  }
+
+  func testAmazonLinux2X86_64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("x86_64").withContainerImageSuffix("amazonlinux2"))
+  }
+
+  func testFedora39Aarch64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("aarch64").withContainerImageSuffix("fedora39"))
+  }
+
+  func testFedora39X86_64FromContainer() async throws {
+    try skipSlow()
+    try await buildTestcases(
+      config: config.withArchitecture("x86_64").withContainerImageSuffix("fedora39"))
+  }
+}
+
+final class Swift61_RHELEndToEndTests: XCTestCase {
+  let config = SDKConfiguration(
+    swiftVersion: "6.1",
     linuxDistributionName: "rhel",
     linuxDistributionVersion: "ubi9",
     architecture: "aarch64",


### PR DESCRIPTION
 - Defaulted `swiftVersion` to "6.1-RELEASE".
 - Added EndToEndTests for Ubuntu and RHEL for Swift61, including some additional tests for Ubuntu Jammy.
 - Fixed missing /lib and /lib64 directories in Ubuntu Noble when building from deb packages. If these directories don't exist, they are symlinked to the correct directories in /usr, which is consistent to what happens when copying from the Docker containers.
 - Added the fix for downloading Swift for the target that adds the platform name to the cache file, to avoid corruption of the artifacts: 
     * <img width="375" alt="image" src="https://github.com/user-attachments/assets/b18efd38-2cbe-44e1-a6fd-2fbb1a13002b" />

 ALSO: I did not include EndToEndTests for Fedora39 for Swift 6.1 since the container is non-existent, likely because it's EOL.