### PR TITLE
Fix use of absolute paths to Swift SDK metatadata

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -113,12 +113,16 @@ extension SwiftSDKGenerator {
         ArtifactsArchiveMetadata(
           schemaVersion: "1.0",
           artifacts: artifacts.mapValues {
-            .init(
+            var relativePath = $0
+            let prefixRemoved = relativePath.removePrefix(pathsConfiguration.artifactBundlePath)
+            assert(prefixRemoved)
+
+            return .init(
               type: .swiftSDK,
               version: self.bundleVersion,
               variants: [
                 .init(
-                  path: $0.string,
+                  path: relativePath.string,
                   supportedTriples: hostTriples.map { $0.map(\.triple) }
                 )
               ]

--- a/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
@@ -10,17 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 import Logging
 import SystemPackage
 import XCTest
 
 @testable import SwiftSDKGenerator
+
+#if canImport(FoundationEssentials)
+  import FoundationEssentials
+#else
+  import Foundation
+#endif
 
 final class SwiftSDKGeneratorMetadataTests: XCTestCase {
   let logger = Logger(label: "SwiftSDKGeneratorMetadataTests")

--- a/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
@@ -10,6 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 import Logging
 import SystemPackage
 import XCTest
@@ -54,19 +60,44 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
 
       // Make sure the file exists
       let sdkSettingsFile = sdkDirPath.appending("SDKSettings.json")
-      let fileExists = await sdk.doesFileExist(at: sdkSettingsFile)
+      var fileExists = await sdk.doesFileExist(at: sdkSettingsFile)
       XCTAssertTrue(fileExists)
 
       // Read back file, make sure it contains the expected data
-      let data = String(data: try await sdk.readFile(at: sdkSettingsFile), encoding: .utf8)
-      XCTAssertNotNil(data)
-      XCTAssertTrue(data!.contains(testCase.bundleVersion))
-      XCTAssertTrue(data!.contains("(\(testCase.targetTriple.archName))"))
-      XCTAssertTrue(data!.contains(linuxDistribution.description))
-      XCTAssertTrue(data!.contains(testCase.expectedCanonicalName))
+      let maybeString = String(data: try await sdk.readFile(at: sdkSettingsFile), encoding: .utf8)
+      let string = try XCTUnwrap(maybeString)
+      XCTAssertTrue(string.contains(testCase.bundleVersion))
+      XCTAssertTrue(string.contains("(\(testCase.targetTriple.archName))"))
+      XCTAssertTrue(string.contains(linuxDistribution.description))
+      XCTAssertTrue(string.contains(testCase.expectedCanonicalName))
 
       // Cleanup
       try await sdk.removeFile(at: sdkSettingsFile)
+
+      try await sdk.createDirectoryIfNeeded(at: sdk.pathsConfiguration.artifactBundlePath)
+
+      // Generate bundle metadata
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [sdk.targetTriple],
+        artifacts: ["foo": sdk.pathsConfiguration.artifactBundlePath.appending("bar.json")]
+      )
+
+      // Make sure the file exists
+      let archiveMetadataFile = await sdk.pathsConfiguration.artifactBundlePath.appending("info.json")
+      fileExists = await sdk.doesFileExist(at: archiveMetadataFile)
+      XCTAssertTrue(fileExists)
+
+      // Read back file, make sure it contains the expected data
+      let data = try await sdk.readFile(at: archiveMetadataFile)
+      let decodedMetadata = try JSONDecoder().decode(ArtifactsArchiveMetadata.self, from: data)
+      XCTAssertEqual(decodedMetadata.artifacts.count, 1)
+      for (id, artifact) in decodedMetadata.artifacts {
+        XCTAssertEqual(id, "foo")
+        XCTAssertEqual(artifact.variants, [.init(path: "bar.json", supportedTriples: [testCase.targetTriple.triple])])
+      }
+
+      // Cleanup
+      try await sdk.removeFile(at: archiveMetadataFile)
     }
   }
 }


### PR DESCRIPTION
The generator incorrectly recorded absolute paths to Swift SDK metadata in bundle archive metadata, which is fragile and also can't be handled by SwiftPM.