### PR TITLE
Symlink `libclang_rt.builtins.a` for Embedded Swift for WASI

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -181,7 +181,7 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
       )
     }
 
-    let autolinkExtractPath = generator.pathsConfiguration.toolchainBinDirPath.appending(
+    let autolinkExtractPath = pathsConfiguration.toolchainBinDirPath.appending(
       "swift-autolink-extract"
     )
 
@@ -194,6 +194,17 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
       logger.info("Fixing `swift-autolink-extract` symlink...")
       try await generator.createSymlink(at: autolinkExtractPath, pointingTo: "swift")
     }
+
+    // Embedded Swift looks up clang compiler-rt in a different path.
+    let embeddedCompilerRTPath = pathsConfiguration.toolchainDirPath.appending(
+      "usr/lib/swift/clang/lib/wasm32-unknown-wasip1"
+    )
+
+    try await generator.createDirectoryIfNeeded(at: embeddedCompilerRTPath)
+    try await generator.createSymlink(
+      at: embeddedCompilerRTPath.appending("libclang_rt.builtins.a"),
+      pointingTo: "../../../../swift_static/clang/lib/wasi/libclang_rt.builtins-wasm32.a"
+    )
 
     // Copy the WASI sysroot into the SDK bundle.
     let sdkDirPath = pathsConfiguration.swiftSDKRootPath.appending("WASI.sdk")

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -197,14 +197,10 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
 
     // Embedded Swift looks up clang compiler-rt in a different path.
     let embeddedCompilerRTPath = pathsConfiguration.toolchainDirPath.appending(
-      "usr/lib/swift/clang/lib/wasm32-unknown-wasip1"
+      "usr/lib/swift/clang/lib/wasip1"
     )
 
-    try await generator.createDirectoryIfNeeded(at: embeddedCompilerRTPath)
-    try await generator.createSymlink(
-      at: embeddedCompilerRTPath.appending("libclang_rt.builtins.a"),
-      pointingTo: "../../../../swift_static/clang/lib/wasi/libclang_rt.builtins-wasm32.a"
-    )
+    try await generator.createSymlink(at: embeddedCompilerRTPath, pointingTo: "wasi")
 
     // Copy the WASI sysroot into the SDK bundle.
     let sdkDirPath = pathsConfiguration.swiftSDKRootPath.appending("WASI.sdk")


### PR DESCRIPTION
Embedded Swift looks up Clang's compiler-rt static library in a different path than non-embedded. These paths could be normalized in the future, but for now the easiest fix seems to be just to symlink the directory the static library is located in.