### PR TITLE
WebAssemblyRecipe: remove `-lswift_ConcurrencyDefaultExecutor` for embedded

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -69,7 +69,7 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
 
       toolset.swiftCompiler?.extraCLIOptions?.append(
         // libraries required for concurrency
-        contentsOf: ["-lc++", "-lswift_Concurrency", "-lswift_ConcurrencyDefaultExecutor"].flatMap {
+        contentsOf: ["-lc++", "-lswift_Concurrency"].flatMap {
           ["-Xlinker", $0]
         }
       )

--- a/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -56,7 +56,7 @@ final class WebAssemblyRecipeTests: XCTestCase {
         "-static-stdlib",
         "-enable-experimental-feature", "Embedded", "-wmo",
       ]
-        + ["-lc++", "-lswift_Concurrency", "-lswift_ConcurrencyDefaultExecutor"].flatMap {
+        + ["-lc++", "-lswift_Concurrency"].flatMap {
           ["-Xlinker", $0]
         }
     )


### PR DESCRIPTION
Embedded Swift Concurrency is currently broken, and linking this library leads to more issues. Let's exclude it for now.