### PR TITLE
Enable `amazonlinux2` in `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: MaxDesiatov/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       linux_pre_build_command: apt-get update && apt-get install -y locales locales-all libsqlite3-dev
       enable_windows_checks: false


### PR DESCRIPTION
Due to frequent regressions with Amazon Linux 2 we should test it on CI.