### PR TITLE
Add missing macOS dependencies to Brewfile, update README.md

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,4 @@
 brew 'xz'
+brew 'zstd'
+brew 'cmake'
+brew 'ninja'

--- a/README.md
+++ b/README.md
@@ -24,18 +24,21 @@ After that, verify that the `experimental-sdk` command is available:
 swift experimental-sdk list
 ```
 
-The output will either state that no Swift SDKs are available, or produce a list of those you previously had 
-installed, in case you've used the `swift experimental-sdk install` command before.
+The output will either state that no Swift SDKs are available, or produce a list of those you previously had installed, in case you've used the `swift experimental-sdk install` command before.
 
 ### macOS Requirements
 
-The generator depends on the `xz` utility for more efficient downloading of package lists for Ubuntu. This is optional, but can be installed via the included `Brewfile`:
+The generator depends on the following dependencies to be installed on macOS:
+
+- `xz`: used for more efficient downloading of package lists for Ubuntu. If `xz` is not found, the generator will fallback on `gzip`.
+- `cmake` and `ninja`: required for building LLVM native for versions of Swift before 6.0.
+- `zstd`: required to decompress certain downloaded artifacts that use [Zstandard](https://github.com/facebook/zstd) compression.
+
+These dependencies can be installed from the `Brewfile`:
 
 ```bash
 brew bundle install
 ```
-
-If `xz` is not found, the generator will fallback on `gzip`.
 
 ## Supported platforms and minimum versions
 


### PR DESCRIPTION
I recently did a clean install of macOS on an Intel MacBook and tried to run the SDK generator on it. I found that a few dependencies were missing from the `Brewfile`, especially when trying to create a Swift SDK for 5.10.1, which requires LLVM to be compiled for the host to include in the SDK.

I've added these dependencies to the Brewfile and also updated the README.md to show what each one is for.

@MaxDesiatov 