### PR TITLE
Bump `swift-tools-version` to 6.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "70c3ef3eba85d6e8ad6a244bfd462ac711414f5d96444d24be8b1bedbf335f58",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -163,5 +164,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -116,8 +116,7 @@ let package = Package(
         .product(name: "Logging", package: "swift-log"),
       ]
     ),
-  ],
-  swiftLanguageVersions: [.v5, .version("6")]
+  ]
 )
 
 struct Configuration {


### PR DESCRIPTION
Since we're no longer directly testing with Swift 5.9 and 5.10, let's try to bump `swift-tools-version` to 6.0 to declare that these older versions are no longer supported.