### PR TITLE
FreeBSD improvements and bug fixes

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -345,12 +345,12 @@ extension GeneratorCLI {
     )
     var freeBSDVersion: String
 
-    func deriveTargetTriple(hostTriples: [Triple], freebsdVersion: String) throws -> Triple {
+    func deriveTargetTriple(hostTriples: [Triple], freeBSDVersion: String) throws -> Triple {
       if let target = generatorOptions.target, target.os == .freeBSD {
         return target
       }
       if let arch = generatorOptions.targetArch {
-        let target = Triple(arch: arch, vendor: nil, os: .freeBSD, version: freebsdVersion)
+        let target = Triple(arch: arch, vendor: nil, os: .freeBSD, version: freeBSDVersion)
         appLogger.warning(
           """
             Using `--target-arch \(arch)` defaults to `\(target.triple)`. \
@@ -375,7 +375,7 @@ extension GeneratorCLI {
       }
 
       let hostTriples = try self.generatorOptions.deriveHostTriples()
-      let targetTriple = try self.deriveTargetTriple(hostTriples: hostTriples, freebsdVersion: self.freeBSDVersion)
+      let targetTriple = try self.deriveTargetTriple(hostTriples: hostTriples, freeBSDVersion: self.freeBSDVersion)
 
       let sourceSwiftToolchain: FilePath?
       if let fromSwiftToolchain {

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -345,12 +345,12 @@ extension GeneratorCLI {
     )
     var freeBSDVersion: String
 
-    func deriveTargetTriple(hostTriples: [Triple]) throws -> Triple {
+    func deriveTargetTriple(hostTriples: [Triple], freebsdVersion: String) throws -> Triple {
       if let target = generatorOptions.target, target.os == .freeBSD {
         return target
       }
       if let arch = generatorOptions.targetArch {
-        let target = Triple(arch: arch, vendor: nil, os: .freeBSD)
+        let target = Triple(arch: arch, vendor: nil, os: .freeBSD, version: freebsdVersion)
         appLogger.warning(
           """
             Using `--target-arch \(arch)` defaults to `\(target.triple)`. \
@@ -375,7 +375,7 @@ extension GeneratorCLI {
       }
 
       let hostTriples = try self.generatorOptions.deriveHostTriples()
-      let targetTriple = try self.deriveTargetTriple(hostTriples: hostTriples)
+      let targetTriple = try self.deriveTargetTriple(hostTriples: hostTriples, freebsdVersion: self.freeBSDVersion)
 
       let sourceSwiftToolchain: FilePath?
       if let fromSwiftToolchain {

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -26,6 +26,11 @@ extension Triple {
     let os = os.rawValue
     self.init("\(arch)-\(vendor?.rawValue ?? "unknown")-\(os)", normalizing: true)
   }
+
+  public init(arch: Arch, vendor: Vendor?, os: OS, version: String) {
+    let os = os.rawValue
+    self.init("\(arch)-\(vendor?.rawValue ?? "unknown")-\(os)\(version)", normalizing: true)
+  }
 }
 
 extension Triple.Arch {

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -18,10 +18,12 @@ extension Triple: @unchecked Sendable {}
 
 extension Triple {
   public init(arch: Arch, vendor: Vendor?, os: OS, environment: Environment) {
+    let os = os.rawValue
     self.init("\(arch)-\(vendor?.rawValue ?? "unknown")-\(os)-\(environment)", normalizing: true)
   }
 
   public init(arch: Arch, vendor: Vendor?, os: OS) {
+    let os = os.rawValue
     self.init("\(arch)-\(vendor?.rawValue ?? "unknown")-\(os)", normalizing: true)
   }
 }


### PR DESCRIPTION
- Include FreeBSD version number in derived target triple
- Always use `rawValue` when using OS enum as string

CC @jakepetroules @MaxDesiatov 