### PR TITLE
WebAssemblyRecipe:: Enable embedded target for wasip1-threads as well

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -125,13 +125,7 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
       ? relativeToolchainDir.appending("usr/lib/swift").string
       : tripleProperties.swiftStaticResourcesPath
 
-    var finalTriple = targetTriple
-    if isForEmbeddedSwift {
-      metadata.targetTriples.removeValue(forKey: targetTriple.triple)
-      finalTriple = Triple("wasm32-unknown-wasip1")
-    }
-
-    metadata.targetTriples[finalTriple.triple] = tripleProperties
+    metadata.targetTriples[targetTriple.triple] = tripleProperties
   }
 
   package func makeSwiftSDK(

--- a/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -99,4 +99,31 @@ final class WebAssemblyRecipeTests: XCTestCase {
       ]
     )
   }
+
+  func testMetadataWithEmbedded() {
+    testMetadataWithEmbedded(targetTriple: Triple("wasm32-unknown-wasip1"))
+    testMetadataWithEmbedded(targetTriple: Triple("wasm32-unknown-wasip1-threads"))
+  }
+
+  func testMetadataWithEmbedded(targetTriple: Triple) {
+    let recipe = self.createRecipe()
+    var metadata = SwiftSDKMetadataV4(
+      targetTriples: [
+        targetTriple.triple: .init(sdkRootPath: "./WASI.sdk")
+      ]
+    )
+    let paths = PathsConfiguration(
+      sourceRoot: "./",
+      artifactID: "any-sdk-id",
+      targetTriple: targetTriple
+    )
+    recipe.applyPlatformOptions(
+      metadata: &metadata,
+      paths: paths,
+      targetTriple: targetTriple,
+      isForEmbeddedSwift: true
+    )
+    // Should include the target we started with.
+    XCTAssertNotNil(metadata.targetTriples[targetTriple.triple])
+  }
 }


### PR DESCRIPTION
There is no reason to limit Embedded Swift to only the non-threads variant. The limitation made some tests in JavaScriptKit a bit more complicated, see e.g. https://github.com/swiftwasm/JavaScriptKit/pull/443/files#diff-2c1174f0c456f8536c09dce2f943c43287a6a207ef08054d6aeddf5f00efa040R86